### PR TITLE
restore SNAPSHOT version in pom...

### DIFF
--- a/environment-setup/pom.xml
+++ b/environment-setup/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.omnifaces.arquillian</groupId>
         <artifactId>parent-glassfish-containers</artifactId>
-        <version>1.2</version>
+        <version>1.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>environment-setup</artifactId>

--- a/glassfish-common/pom.xml
+++ b/glassfish-common/pom.xml
@@ -66,7 +66,7 @@
     <parent>
         <groupId>org.omnifaces.arquillian</groupId>
         <artifactId>parent-glassfish-containers</artifactId>
-        <version>1.2</version>
+        <version>1.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>glassfish-container-common</artifactId>

--- a/glassfish-embedded/pom.xml
+++ b/glassfish-embedded/pom.xml
@@ -64,7 +64,7 @@
     <parent>
         <groupId>org.omnifaces.arquillian</groupId>
         <artifactId>parent-glassfish-containers</artifactId>
-        <version>1.2</version>
+        <version>1.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>arquillian-glassfish-server-embedded</artifactId>

--- a/glassfish-managed/pom.xml
+++ b/glassfish-managed/pom.xml
@@ -65,7 +65,7 @@
     <parent>
         <groupId>org.omnifaces.arquillian</groupId>
         <artifactId>parent-glassfish-containers</artifactId>
-        <version>1.2</version>
+        <version>1.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>arquillian-glassfish-server-managed</artifactId>

--- a/glassfish-remote/pom.xml
+++ b/glassfish-remote/pom.xml
@@ -65,7 +65,7 @@
     <parent>
         <groupId>org.omnifaces.arquillian</groupId>
         <artifactId>parent-glassfish-containers</artifactId>
-        <version>1.2</version>
+        <version>1.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>arquillian-glassfish-server-remote</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -45,7 +45,7 @@
     <parent>
         <groupId>org.omnifaces.arquillian</groupId>
         <artifactId>parent-glassfish-containers</artifactId>
-        <version>1.2</version>
+        <version>1.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>integration-tests</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
     <groupId>org.omnifaces.arquillian</groupId>
     <artifactId>parent-glassfish-containers</artifactId>
-    <version>1.2</version>
+    <version>1.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Arquillian Container Parent GlassFish</name>


### PR DESCRIPTION
please avoid non SNAPSHOT in poms after a release.
I just wanted to test something and so mvn install just override local version of 1.2
This can generate a lot of confusions and problems!!
Thanks
Signed-off-by: Olivier Lamy <olamy@apache.org>
