### PR TITLE
Fixed classpath clashes

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -74,76 +74,12 @@
     <name>Arquillian Container for GlassFish - Dependencies POM</name>
 
     <properties>
-        <version.jackson>2.19.2</version.jackson>
-        <version.jersey>3.1.10</version.jersey>
         <version.parsson>1.1.7</version.parsson>
         <version.arquillian.jee>10.0.0.Final</version.arquillian.jee>
     </properties>
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.glassfish.jersey.core</groupId>
-                <artifactId>jersey-client</artifactId>
-                <version>${version.jersey}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.inject</groupId>
-                <artifactId>jersey-hk2</artifactId>
-                <version>${version.jersey}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.ext</groupId>
-                <artifactId>jersey-proxy-client</artifactId>
-                <version>${version.jersey}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.ext</groupId>
-                <artifactId>jersey-microprofile-rest-client</artifactId>
-                <version>${version.jersey}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.core</groupId>
-                <artifactId>jersey-common</artifactId>
-                <version>${version.jersey}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.core</groupId>
-                <artifactId>jersey-server</artifactId>
-                <version>${version.jersey}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.media</groupId>
-                <artifactId>jersey-media-sse</artifactId>
-                <version>${version.jersey}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.media</groupId>
-                <artifactId>jersey-media-multipart</artifactId>
-                <version>${version.jersey}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.media</groupId>
-                <artifactId>jersey-media-jaxb</artifactId>
-                <version>${version.jersey}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jersey.media</groupId>
-                <artifactId>jersey-media-json-processing</artifactId>
-                <version>${version.jersey}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.fasterxml.jackson.module</groupId>
-                <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
-                <version>${version.jackson}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${version.jackson}</version>
-            </dependency>
-
             <dependency>
                 <groupId>org.eclipse.parsson</groupId>
                 <artifactId>parsson</artifactId>
@@ -153,19 +89,6 @@
                 <groupId>org.eclipse.parsson</groupId>
                 <artifactId>parsson-media</artifactId>
                 <version>${version.parsson}</version>
-            </dependency>
-
-            <!-- Note: indirectly depends on javax.* -->
-            <dependency>
-                <groupId>org.glassfish.jersey.media</groupId>
-                <artifactId>jersey-media-json-jackson</artifactId>
-                <version>${version.jersey}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>jakarta.xml.bind</groupId>
-                <artifactId>jakarta.xml.bind-api</artifactId>
-                <version>4.0.2</version>
             </dependency>
 
             <dependency>

--- a/glassfish-common/pom.xml
+++ b/glassfish-common/pom.xml
@@ -85,50 +85,37 @@
         </dependency>
 
         <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-client</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>4.0.2</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jersey.inject</groupId>
-            <artifactId>jersey-hk2</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <version>4.0.0</version>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-common</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-server</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-sse</artifactId>
-            <optional>true</optional>
-        </dependency>
+
         <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-multipart</artifactId>
+            <version>4.0.0-M2</version>
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-jaxb</artifactId>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-client</artifactId>
+            <version>4.0.0-M2</version>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-json-processing</artifactId>
+         <dependency>
+             <groupId>org.glassfish.jersey.incubator</groupId>
+             <artifactId>jersey-injectless-client</artifactId>
+            <version>4.0.0-M2</version>
             <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-json-jackson</artifactId>
-            <optional>true</optional>
-        </dependency>
+         </dependency>
+
         <dependency>
             <groupId>org.eclipse.parsson</groupId>
             <artifactId>parsson</artifactId>
@@ -137,23 +124,6 @@
         <dependency>
             <groupId>org.eclipse.parsson</groupId>
             <artifactId>parsson-media</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
             <optional>true</optional>
         </dependency>
 
@@ -171,6 +141,121 @@
         <plugins>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <artifactSet>
+                                <includes>
+                                    <!-- Jakarta EE -->
+                                    <include>jakarta.activation:*</include>
+                                    <include>jakarta.annotation:*</include>
+                                    <include>jakarta.inject:*</include>
+                                    <include>jakarta.json:*</include>
+                                    <include>jakarta.validation:*</include>
+                                    <include>jakarta.ws.rs:*</include>
+                                    <include>jakarta.xml.bind:*</include>
+
+                                    <!-- GlassFish -->
+                                    <include>org.glassfish.jersey.core:*</include>
+                                    <include>org.glassfish.jersey.media:*</include>
+                                    <include>org.glassfish.jersey.incubator:*</include>
+                                    <include>org.eclipse.parsson:parsson:*</include>
+                                    <include>org.eclipse.parsson:parsson-media:*</include>
+
+                                    <!-- Other -->
+                                    <include>org.jvnet:*</include>
+                                    <include>org.jvnet.mimepull:*</include>
+                                </includes>
+                            </artifactSet>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/NOTICE*</exclude>
+                                        <exclude>META-INF/LICENSE*</exclude>
+                                        <exclude>META-INF/native-image/**/*</exclude>
+                                        <exclude>META-INF/services/jakarta*</exclude>
+                                        <exclude>META-INF/services/org*</exclude>
+                                        <exclude>META-INF/versions/*/module-info.class</exclude>
+                                        <exclude>module-info.class</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Multi-Release>true</Multi-Release>
+                                    </manifestEntries>
+                                </transformer>
+                            </transformers>
+
+                            <relocations>
+                                <!-- Jakarta EE -->
+                                <relocation>
+                                    <pattern>jakarta.activation</pattern>
+                                    <shadedPattern>ee.omnifish.arquillian.activation</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>jakarta.annotation</pattern>
+                                    <shadedPattern>ee.omnifish.arquillian.annotation</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>jakarta.inject</pattern>
+                                    <shadedPattern>ee.omnifish.arquillian.inject</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>jakarta.json</pattern>
+                                    <shadedPattern>ee.omnifish.arquillian.json</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>jakarta.ws</pattern>
+                                    <shadedPattern>ee.omnifish.arquillian.ws</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>jakarta.xml.bind</pattern>
+                                    <shadedPattern>ee.omnifish.arquillian.xml.bind</shadedPattern>
+                                </relocation>
+
+                                <!-- GlassFish -->
+                                <relocation>
+                                    <pattern>org.glassfish.jersey</pattern>
+                                    <shadedPattern>ee.omnifish.arquillian.jersey</shadedPattern>
+                                </relocation>
+
+                                <!-- Other -->
+                                <relocation>
+                                    <pattern>com.fasterxml.jackson</pattern>
+                                    <shadedPattern>ee.omnifish.arquillian.jackson</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.sun.research</pattern>
+                                    <shadedPattern>ee.omnifish.arquillian.research</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.eclipse.parsson</pattern>
+                                    <shadedPattern>ee.omnifish.arquillian.parsson</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.jvnet</pattern>
+                                    <shadedPattern>ee.omnifish.arquillian.jvnet</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>META-INF/versions/21/org.glassfish.jersey.innate</pattern>
+                                    <shadedPattern>META-INF/versions/21/ee.omnifish.arquillian.jersey.innate</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/glassfish-common/src/main/java/ee/omnifish/arquillian/container/glassfish/CommonGlassFishManager.java
+++ b/glassfish-common/src/main/java/ee/omnifish/arquillian/container/glassfish/CommonGlassFishManager.java
@@ -58,6 +58,8 @@
 // Portions Copyright [2021] [OmniFaces and/or its affiliates]
 package ee.omnifish.arquillian.container.glassfish;
 
+import jakarta.ws.rs.ProcessingException;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.System.Logger;
@@ -69,7 +71,6 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.file.StreamDataBodyPart;
-import org.glassfish.jersey.server.ContainerException;
 import org.jboss.arquillian.container.spi.client.container.DeploymentException;
 import org.jboss.arquillian.container.spi.client.container.LifecycleException;
 import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
@@ -156,7 +157,7 @@ public class CommonGlassFishManager<C extends CommonGlassFishConfiguration> {
             final ProtocolMetaData protocolMetaData = new ProtocolMetaData();
             protocolMetaData.addContext(httpContext);
             return protocolMetaData;
-        } catch (GlassFishClientException | IOException | ContainerException e) {
+        } catch (GlassFishClientException | IOException | ProcessingException e) {
             throw new DeploymentException("Could not deploy " + archiveName + " as " + deploymentName, e);
         }
     }
@@ -181,7 +182,7 @@ public class CommonGlassFishManager<C extends CommonGlassFishConfiguration> {
             } finally {
                 deployLock.unlock();
             }
-        } catch (GlassFishClientException | ContainerException e) {
+        } catch (GlassFishClientException | ProcessingException e) {
             throw new DeploymentException("Could not undeploy " + archive.getName(), e);
         }
     }

--- a/glassfish-common/src/main/resources/META-INF/services/ee.omnifish.arquillian.jersey.internal.inject.InjectionManagerFactory
+++ b/glassfish-common/src/main/resources/META-INF/services/ee.omnifish.arquillian.jersey.internal.inject.InjectionManagerFactory
@@ -1,0 +1,1 @@
+ee.omnifish.arquillian.jersey.inject.injectless.NonInjectionManagerFactory

--- a/glassfish-common/src/main/resources/META-INF/services/ee.omnifish.arquillian.ws.rs.client.ClientBuilder
+++ b/glassfish-common/src/main/resources/META-INF/services/ee.omnifish.arquillian.ws.rs.client.ClientBuilder
@@ -1,0 +1,1 @@
+ee.omnifish.arquillian.jersey.client.JerseyClientBuilder

--- a/glassfish-common/src/main/resources/META-INF/services/ee.omnifish.arquillian.ws.rs.ext.RuntimeDelegate
+++ b/glassfish-common/src/main/resources/META-INF/services/ee.omnifish.arquillian.ws.rs.ext.RuntimeDelegate
@@ -1,0 +1,1 @@
+ee.omnifish.arquillian.jersey.internal.RuntimeDelegateImpl

--- a/glassfish-managed/pom.xml
+++ b/glassfish-managed/pom.xml
@@ -133,12 +133,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-server</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
         <version.gjule>${version.glassfish}</version.gjule>
         <version.jakartaee>10</version.jakartaee>
         <version.jakartaee.api>10.0.0</version.jakartaee.api>
+        <version.jackson>2.19.2</version.jackson>
         <version.shrinkwrap>1.2.6</version.shrinkwrap>
         <glassfish.home>glassfish7</glassfish.home>
 
@@ -141,6 +142,18 @@
                 <groupId>jakarta.platform</groupId>
                 <artifactId>jakarta.jakartaee-api</artifactId>
                 <version>${version.jakartaee.api}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-jakarta-xmlbind-annotations</artifactId>
+                <version>${version.jackson}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${version.jackson}</version>
                 <scope>provided</scope>
             </dependency>
 
@@ -306,159 +319,6 @@
                 <plugin>
                     <artifactId>maven-shade-plugin</artifactId>
                     <version>3.6.0</version>
-                    <executions>
-                        <execution>
-                            <phase>package</phase>
-                            <goals>
-                                <goal>shade</goal>
-                            </goals>
-                            <configuration>
-                                <createDependencyReducedPom>false</createDependencyReducedPom>
-                                <artifactSet>
-                                    <includes>
-                                        <!-- Jakarta EE -->
-                                        <include>jakarta.activation:*</include>
-                                        <include>jakarta.annotation:jakarta.annotation-api:*</include>
-                                        <include>jakarta.inject:*</include>
-                                        <include>jakarta.json:*</include>
-                                        <include>jakarta.validation:jakarta.validation-api:*</include>
-                                        <include>jakarta.ws.rs:jakarta.ws.rs-api:*</include>
-                                        <include>jakarta.xml.bind:*</include>
-
-                                        <!-- GlassFish -->
-                                        <include>org.glassfish:*</include>
-                                        <include>org.glassfish.hk2</include>
-                                        <include>org.glassfish.hk2.external:*</include>
-                                        <include>org.glassfish.jersey.core:*</include>
-                                        <include>org.glassfish.jersey.inject:*</include>
-                                        <include>org.glassfish.jersey.innate:*</include>
-                                        <include>org.glassfish.jersey.media:*</include>
-                                        <include>org.glassfish.jersey.ext:*</include>
-                                        <include>org.eclipse.parsson:parsson:*</include>
-                                        <include>org.eclipse.parsson:parsson-media:*</include>
-
-                                        <!-- Other -->
-                                        <include>com.fasterxml.jackson.core:*</include>
-                                        <include>com.fasterxml.jackson.module:*</include>
-                                        <include>org.javassist:*</include>
-                                        <include>org.jvnet:*</include>
-                                        <include>org.jvnet.mimepull:*</include>
-                                    </includes>
-                                </artifactSet>
-                                <filters>
-                                    <filter>
-                                        <artifact>*:*</artifact>
-                                        <excludes>
-                                            <exclude>META-INF/MANIFEST.MF</exclude>
-                                            <exclude>META-INF/NOTICE*</exclude>
-                                            <exclude>META-INF/LICENSE*</exclude>
-                                            <exclude>META-INF/versions/*/module-info.class</exclude>
-                                            <exclude>module-info.class</exclude>
-                                        </excludes>
-                                    </filter>
-                                </filters>
-
-                                <transformers>
-                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                        <manifestEntries>
-                                            <Multi-Release>true</Multi-Release>
-                                        </manifestEntries>
-                                    </transformer>
-                                </transformers>
-
-                                <relocations>
-                                    <!-- Jakarta EE -->
-                                    <relocation>
-                                        <pattern>jakarta.activation</pattern>
-                                        <shadedPattern>ee.omnifish.arquillian.activation</shadedPattern>
-                                    </relocation>
-                                    <relocation>
-                                        <pattern>jakarta.annotation</pattern>
-                                        <shadedPattern>ee.omnifish.arquillian.annotation</shadedPattern>
-                                    </relocation>
-                                    <relocation>
-                                        <pattern>jakarta.inject</pattern>
-                                        <shadedPattern>ee.omnifish.arquillian.inject</shadedPattern>
-                                    </relocation>
-                                    <relocation>
-                                        <pattern>jakarta.json</pattern>
-                                        <shadedPattern>ee.omnifish.arquillian.json</shadedPattern>
-                                    </relocation>
-                                    <relocation>
-                                        <pattern>jakarta.validation</pattern>
-                                        <shadedPattern>ee.omnifish.arquillian.validation</shadedPattern>
-                                    </relocation>
-                                    <relocation>
-                                        <pattern>jakarta.ws</pattern>
-                                        <shadedPattern>ee.omnifish.arquillian.ws</shadedPattern>
-                                    </relocation>
-                                    <relocation>
-                                        <pattern>jakarta.xml.bind</pattern>
-                                        <shadedPattern>ee.omnifish.arquillian.xml.bind</shadedPattern>
-                                    </relocation>
-
-                                    <!-- GlassFish -->
-                                    <relocation>
-                                        <pattern>org.glassfish.hk2</pattern>
-                                        <shadedPattern>ee.omnifish.arquillian.hk2</shadedPattern>
-                                    </relocation>
-                                    <relocation>
-                                        <pattern>org.glassfish.jersey</pattern>
-                                        <shadedPattern>ee.omnifish.arquillian.jersey</shadedPattern>
-                                    </relocation>
-
-                                    <!-- Other -->
-                                    <relocation>
-                                        <pattern>com.fasterxml.jackson</pattern>
-                                        <shadedPattern>ee.omnifish.arquillian.jackson</shadedPattern>
-                                    </relocation>
-                                    <relocation>
-                                        <pattern>com.sun.research</pattern>
-                                        <shadedPattern>ee.omnifish.arquillian.research</shadedPattern>
-                                    </relocation>
-                                    <relocation>
-                                        <pattern>javassist</pattern>
-                                        <shadedPattern>ee.omnifish.arquillian.javassist</shadedPattern>
-                                    </relocation>
-                                    <relocation>
-                                        <pattern>jersey.repackaged</pattern>
-                                        <shadedPattern>ee.omnifish.arquillian.jersey.repackaged</shadedPattern>
-                                    </relocation>
-                                    <relocation>
-                                        <pattern>org.aopalliance</pattern>
-                                        <shadedPattern>ee.omnifish.arquillian.aopalliance</shadedPattern>
-                                    </relocation>
-                                    <relocation>
-                                        <pattern>org.eclipse.parsson</pattern>
-                                        <shadedPattern>ee.omnifish.arquillian.parsson</shadedPattern>
-                                    </relocation>
-                                    <relocation>
-                                        <pattern>org.jvnet</pattern>
-                                        <shadedPattern>ee.omnifish.arquillian.jvnet</shadedPattern>
-                                    </relocation>
-
-                                    <relocation>
-                                        <pattern>META-INF/versions/11/com.fasterxml.jackson</pattern>
-                                        <shadedPattern>META-INF/versions/11/ee.omnifish.arquillian.jackson</shadedPattern>
-                                    </relocation>
-                                    <relocation>
-                                        <pattern>META-INF/versions/17/com.fasterxml.jackson</pattern>
-                                        <shadedPattern>META-INF/versions/17/ee.omnifish.arquillian.jackson</shadedPattern>
-                                    </relocation>
-                                    <relocation>
-                                        <pattern>META-INF/versions/21/com.fasterxml.jackson</pattern>
-                                        <shadedPattern>META-INF/versions/21/ee.omnifish.arquillian.jackson</shadedPattern>
-                                    </relocation>
-                                    <relocation>
-                                        <pattern>META-INF/versions/21/org.glassfish.jersey.innate</pattern>
-                                        <shadedPattern>META-INF/versions/21/ee.omnifish.arquillian.jersey.innate</shadedPattern>
-                                    </relocation>
-                                </relocations>
-                            </configuration>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.cyclonedx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -317,15 +317,13 @@
                                 <artifactSet>
                                     <includes>
                                         <!-- Jakarta EE -->
-                                        <include>jakarta.validation:jakarta.validation-api:*</include>
+                                        <include>jakarta.activation:*</include>
                                         <include>jakarta.annotation:jakarta.annotation-api:*</include>
-                                        <include>jakarta.ws.rs:jakarta.ws.rs-api:*</include>
                                         <include>jakarta.inject:*</include>
                                         <include>jakarta.json:*</include>
-
+                                        <include>jakarta.validation:jakarta.validation-api:*</include>
+                                        <include>jakarta.ws.rs:jakarta.ws.rs-api:*</include>
                                         <include>jakarta.xml.bind:*</include>
-
-                                        <include>jakarta.activation:*</include>
 
                                         <!-- GlassFish -->
                                         <include>org.glassfish:*</include>
@@ -333,15 +331,16 @@
                                         <include>org.glassfish.hk2.external:*</include>
                                         <include>org.glassfish.jersey.core:*</include>
                                         <include>org.glassfish.jersey.inject:*</include>
+                                        <include>org.glassfish.jersey.innate:*</include>
                                         <include>org.glassfish.jersey.media:*</include>
                                         <include>org.glassfish.jersey.ext:*</include>
                                         <include>org.eclipse.parsson:parsson:*</include>
                                         <include>org.eclipse.parsson:parsson-media:*</include>
 
                                         <!-- Other -->
-                                        <include>org.javassist:*</include>
                                         <include>com.fasterxml.jackson.core:*</include>
                                         <include>com.fasterxml.jackson.module:*</include>
+                                        <include>org.javassist:*</include>
                                         <include>org.jvnet:*</include>
                                         <include>org.jvnet.mimepull:*</include>
                                     </includes>
@@ -362,6 +361,11 @@
                                 <transformers>
                                     <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                                     <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
+                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                        <manifestEntries>
+                                            <Multi-Release>true</Multi-Release>
+                                        </manifestEntries>
+                                    </transformer>
                                 </transformers>
 
                                 <relocations>
@@ -407,7 +411,7 @@
 
                                     <!-- Other -->
                                     <relocation>
-                                        <pattern>com.fasterxml</pattern>
+                                        <pattern>com.fasterxml.jackson</pattern>
                                         <shadedPattern>ee.omnifish.arquillian.jackson</shadedPattern>
                                     </relocation>
                                     <relocation>
@@ -433,6 +437,23 @@
                                     <relocation>
                                         <pattern>org.jvnet</pattern>
                                         <shadedPattern>ee.omnifish.arquillian.jvnet</shadedPattern>
+                                    </relocation>
+
+                                    <relocation>
+                                        <pattern>META-INF/versions/11/com.fasterxml.jackson</pattern>
+                                        <shadedPattern>META-INF/versions/11/ee.omnifish.arquillian.jackson</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>META-INF/versions/17/com.fasterxml.jackson</pattern>
+                                        <shadedPattern>META-INF/versions/17/ee.omnifish.arquillian.jackson</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>META-INF/versions/21/com.fasterxml.jackson</pattern>
+                                        <shadedPattern>META-INF/versions/21/ee.omnifish.arquillian.jackson</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>META-INF/versions/21/org.glassfish.jersey.innate</pattern>
+                                        <shadedPattern>META-INF/versions/21/ee.omnifish.arquillian.jersey.innate</shadedPattern>
                                     </relocation>
                                 </relocations>
                             </configuration>


### PR DESCRIPTION
- The point is that we shade what we do need and what should not interact with
  tests - but it did. So what I am doing here is:
- Removed most of service files which caused clashes
- Removed most of dependencies we don't need or we do need, but we will use
  compatible versions depending on the platform (JEE10/11/...)
- Fixed relocation in multirelease jars
- The common has 2 MB not 7 as before
- It is quite large change, so we should release it as 2.1.0
- Tested on TCK vs. GF8