### PR TITLE
Add GlassFish pool container for parallel Arquillian test runs

### DIFF
--- a/glassfish-pool-maven-plugin/README.md
+++ b/glassfish-pool-maven-plugin/README.md
@@ -139,7 +139,17 @@ plus a `<destFileName>`:
 </configuration>
 ```
 
-Skip in CI without editing the pom: `mvn verify -Dgf.pool.overlay.skip=true`.
+| Overlay element | Type    | Default                          | Notes                                                   |
+| --------------- | ------- | -------------------------------- | ------------------------------------------------------- |
+| `groupId` / `artifactId` / `version` / `type` / `classifier` | String  | (GAV)                            | Maven coordinate to resolve.                            |
+| `destFileName`  | String  | source artifact's file name      | File name to copy under `overlayTargetDir`.             |
+| `skip`          | boolean | `false`                          | Skip just this overlay. Property-driven for per-profile toggling, e.g. `<skip>${soteria.noupdate}</skip>`. |
+
+`overlaySkip` is the master kill-switch (skip *all* overlays); per-overlay
+`<skip>` lets you hold back a subset (e.g. keep the API jar pinned but
+opt out of the impl overlay against a SNAPSHOT it doesn't yet match).
+
+Skip everything in CI without editing the pom: `mvn verify -Dgf.pool.overlay.skip=true`.
 
 ## Recipes
 

--- a/glassfish-pool-maven-plugin/README.md
+++ b/glassfish-pool-maven-plugin/README.md
@@ -1,0 +1,226 @@
+# Arquillian Container GlassFish Pool — Maven Plugin
+
+Maven plugin that drives the lifecycle of an
+[`arquillian-glassfish-server-pool`](../glassfish-pool/) pool. Binds
+naturally to `pre-integration-test` / `post-integration-test` so a
+consumer pom only has to add three plugin blocks (this one, dependency
+unpack, and failsafe) to get a parallel-fork-friendly pool of GlassFish
+instances.
+
+| Coordinates  | Value                              |
+| ------------ | ---------------------------------- |
+| `groupId`    | `ee.omnifish.arquillian`           |
+| `artifactId` | `glassfish-pool-maven-plugin`      |
+| Goal prefix  | `glassfish-pool`                   |
+| Maven        | 3.9.0+                             |
+
+## Goals
+
+| Goal        | Default phase            | Purpose                                             |
+| ----------- | ------------------------ | --------------------------------------------------- |
+| `up`        | `pre-integration-test`   | Stage GlassFish (optional), provision and start every slot in parallel. Idempotent — re-running fast-exits if all slots are healthy. |
+| `down`      | `post-integration-test`  | Stop every slot's domain. Best-effort.              |
+| `provision` | (none)                   | Provision a single extra slot at `-Dgf.pool.slot=N`. Mostly debugging — `SlotLeaser` grows the pool itself when test JVMs need it. |
+| `status`    | (none)                   | Print one row per slot: index, admin port, alive, leased. Live-refreshes on a TTY (like `top`); one-shot when piped or under `-B`. |
+| `nuke`      | (none)                   | Stop every slot AND remove the pool directory. Forceful reset before a clean `up`. |
+
+## Quick start
+
+Bind `up` and `down` to the integration-test phases, point `failsafe` at the
+same `poolDir`, and run `mvn verify`:
+
+```xml
+<plugin>
+    <groupId>ee.omnifish.arquillian</groupId>
+    <artifactId>glassfish-pool-maven-plugin</artifactId>
+    <version>2.1.4</version>
+    <configuration>
+        <poolDir>${project.build.directory}/pool</poolDir>
+        <poolSource>${project.build.directory}/dist/glassfish9</poolSource>
+        <poolSize>4</poolSize>
+    </configuration>
+    <executions>
+        <execution><id>pool-up</id><goals><goal>up</goal></goals></execution>
+        <execution><id>pool-down</id><goals><goal>down</goal></goals></execution>
+    </executions>
+</plugin>
+```
+
+For the full three-plugin wiring (dependency unpack + this plugin +
+failsafe), see [`../glassfish-pool/README.md`](../glassfish-pool/README.md#end-to-end-maven-setup).
+
+The plugin does **not** download a GlassFish distribution unless you supply
+the `<distribution>` block (see *Auto-staging*). Most builds let
+`maven-dependency-plugin` unpack into `${project.build.directory}/dist` and
+point `poolSource` at the result.
+
+## Configuration reference
+
+All goals share the parameters in *Common* below. `up` and `provision` add
+the *Staging* block.
+
+### Common (all goals)
+
+| Parameter       | Property             | Default                         | Notes                                                  |
+| --------------- | -------------------- | ------------------------------- | ------------------------------------------------------ |
+| `poolDir`       | `gf.pool.dir`        | `${project.build.directory}/pool` | Pool root. Created if missing. **Required.**         |
+| `poolSource`    | `gf.pool.source`     | (none)                          | Source GlassFish install. Required for `up`/`provision`. |
+| `poolSize`      | `gf.pool.size`       | `1`                             | Number of slots `up` provisions.                       |
+| `adminPortBase` | `gf.pool.adminBase`  | `14848`                         | Admin port for slot 1.                                 |
+| `portStride`    | `gf.pool.portStride` | `100`                           | Per-slot port spacing. Must be ≥ 10.                   |
+| `skip`          | `gf.pool.skip`       | `false`                         | Skip the goal. Combine with `-DskipTests`/`-Dmaven.test.skip` to disable the lifecycle without removing the binding. |
+
+`up` additionally honours `-DskipTests` and `-Dmaven.test.skip` — if the
+build isn't running tests there's no reason to pay for a pool.
+
+### Staging (`up`, `provision`)
+
+| Parameter         | Property               | Default                          | Notes                                                                  |
+| ----------------- | ---------------------- | -------------------------------- | ---------------------------------------------------------------------- |
+| `distribution`    | (nested `<distribution>`) | (none)                        | Optional GAV of a GlassFish dist to resolve and unpack into `stageDir`. |
+| `stageDir`        | `gf.pool.stageDir`     | `${project.build.directory}/dist`| Where the dist zip is unpacked.                                        |
+| `unpackSkip`      | `gf.pool.unpack.skip`  | `false`                          | Skip the unpack — assume `poolSource` already points at a staged install. |
+| `overlays`        | (nested `<overlays>`)  | (empty)                          | Artifacts copied into `overlayTargetDir` after unpack. See *Overlays*.  |
+| `overlayTargetDir`| `gf.pool.overlayTargetDir` | `${poolSource}/glassfish/modules` | Where overlay jars land. Default matches the standard GlassFish layout. |
+| `overlaySkip`     | `gf.pool.overlay.skip` | `false`                          | Skip overlay copying.                                                  |
+
+`provision` additionally requires `-Dgf.pool.slot=N`.
+
+## Auto-staging (skip the dependency-plugin block)
+
+If you'd rather have the plugin resolve the dist itself — useful for TCK-style
+builds that swap GlassFish versions per profile — declare a `<distribution>`
+block. The plugin uses Aether to resolve the artifact through your usual
+repositories and unpacks it under `<stageDir>` before provisioning runs.
+
+```xml
+<plugin>
+    <groupId>ee.omnifish.arquillian</groupId>
+    <artifactId>glassfish-pool-maven-plugin</artifactId>
+    <version>2.1.4</version>
+    <configuration>
+        <poolDir>${project.build.directory}/pool</poolDir>
+        <poolSource>${project.build.directory}/dist/glassfish9</poolSource>
+        <poolSize>4</poolSize>
+        <distribution>
+            <groupId>org.glassfish.main.distributions</groupId>
+            <artifactId>glassfish</artifactId>
+            <version>9.0.0</version>
+            <type>zip</type>
+        </distribution>
+    </configuration>
+    <executions>
+        <execution><id>pool-up</id><goals><goal>up</goal></goals></execution>
+        <execution><id>pool-down</id><goals><goal>down</goal></goals></execution>
+    </executions>
+</plugin>
+```
+
+Staging runs once per pool — re-runs fast-exit when the marker file written
+after a successful unpack is still present. Set `<unpackSkip>true</unpackSkip>`
+to short-circuit the check entirely.
+
+## Overlays
+
+Drop additional jars (or replace shipped ones) into the staged install's
+`modules/` directory before slot cloning. Each `<overlay>` is a Maven GAV
+plus a `<destFileName>`:
+
+```xml
+<configuration>
+    <overlays>
+        <overlay>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.faces</artifactId>
+            <version>5.0.0</version>
+            <destFileName>jakarta.faces.jar</destFileName>
+        </overlay>
+    </overlays>
+</configuration>
+```
+
+Skip in CI without editing the pom: `mvn verify -Dgf.pool.overlay.skip=true`.
+
+## Recipes
+
+### Run from the command line, no project binding
+
+```
+mvn ee.omnifish.arquillian:glassfish-pool-maven-plugin:status \
+    -Dgf.pool.dir=target/pool
+```
+
+`status` and `nuke` declare `requiresProject = false`, so they work outside a
+project (handy for poking at a pool another build left behind).
+
+### Live status table
+
+```
+mvn glassfish-pool:status -Dgf.pool.dir=target/pool
+```
+
+On an interactive TTY the table redraws every second until Ctrl+C.
+Force one-shot in a TTY with `-Dgf.pool.once`. CI runs (`-B` /
+`--batch-mode`) always print one frame and exit — they don't fill logs with
+redraw frames.
+
+### Add an extra slot to a running pool
+
+```
+mvn glassfish-pool:provision \
+    -Dgf.pool.dir=target/pool \
+    -Dgf.pool.source=target/dist/glassfish9 \
+    -Dgf.pool.slot=5
+```
+
+Day-to-day this is rarely needed — the test-JVM leaser grows the pool
+itself when it can't find an idle slot.
+
+### Wipe and start over
+
+```
+mvn glassfish-pool:nuke -Dgf.pool.dir=target/pool
+```
+
+Stops every slot, then deletes the pool directory. The next `up` cold-starts
+everything.
+
+### Skip the lifecycle in a build
+
+`-Dgf.pool.skip=true` short-circuits every goal. `-DskipTests` /
+`-Dmaven.test.skip` skip just `up` (and by transitive intent, `down` —
+there's nothing to stop).
+
+## Cross-build coordination
+
+Locks inside `poolDir` (`grow.lock`, per-slot `lock`) coordinate JVMs that
+share the same `poolDir`. They do **not** coordinate two `mvn` invocations
+that target the same `poolDir` at once — the second `up` will collide with
+the first on cloning. Run parallel `mvn` invocations against distinct
+`poolDir`s (or distinct `adminPortBase` values).
+
+A JVM shutdown hook installed by `up` calls `down` if the Maven process is
+killed (Ctrl+C, hard build failure), so slots don't get orphaned.
+
+## Troubleshooting
+
+- **`Pool up failed: ... Address already in use`** — another process holds a
+  port in the slot's window. Pick a different `adminPortBase`, or `nuke`
+  any stale pool that didn't shut down cleanly.
+- **`Slot N provisioning failed during grow`** — usually means
+  `gf.pool.source` is wrong or the source install is corrupt. `mvn
+  glassfish-pool:status` will show the slot stuck in `bootstrap`; `nuke` and
+  retry.
+- **Status table garbled in CI** — CI is being detected as interactive.
+  Add `-B` (batch mode) or `-Dgf.pool.once`.
+- **`portStride must be >= 10`** — a GlassFish domain uses ~10 ports;
+  shrinking the stride collides them.
+
+## Related modules
+
+- [`arquillian-glassfish-server-pool`](../glassfish-pool/) — the runtime
+  this plugin drives. Read its README for the architecture and the
+  `arquillian.xml` setup.
+- [`integration-tests/src/it/pool`](../integration-tests/src/it/pool) —
+  worked example: dependency-plugin unpack + this plugin + failsafe +
+  Arquillian, all in one ~150-line pom.

--- a/glassfish-pool-maven-plugin/pom.xml
+++ b/glassfish-pool-maven-plugin/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ee.omnifish.arquillian</groupId>
+        <artifactId>glassfish-containers-dependencies</artifactId>
+        <version>2.1.4-SNAPSHOT</version>
+        <relativePath>../dependencies</relativePath>
+    </parent>
+
+    <artifactId>glassfish-pool-maven-plugin</artifactId>
+    <packaging>maven-plugin</packaging>
+
+    <name>Arquillian Container GlassFish Pool — Maven Plugin</name>
+    <description>
+        Lifecycle goals (up/down/provision/status/nuke) wrapping
+        ee.omnifish.arquillian:arquillian-glassfish-server-pool. Lets a
+        consumer pom bind pool-up to pre-integration-test and pool-down to
+        post-integration-test.
+    </description>
+
+    <prerequisites>
+        <maven>3.9.0</maven>
+    </prerequisites>
+
+    <properties>
+        <version.maven.plugin>3.9.0</version.maven.plugin>
+        <version.maven.plugin.annotations>3.15.1</version.maven.plugin.annotations>
+        <version.maven.plugin.plugin>3.15.1</version.maven.plugin.plugin>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>ee.omnifish.arquillian</groupId>
+            <artifactId>arquillian-glassfish-server-pool</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>${version.maven.plugin}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>${version.maven.plugin}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>${version.maven.plugin.annotations}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Aether resolver: used by UpMojo/ProvisionMojo to fetch the
+             GlassFish dist + overlay artifacts ahead of slot provisioning. -->
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-api</artifactId>
+            <version>1.9.18</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- glassfish-pool declares commons-compress as optional (test-JVM
+             consumers don't need it). The plugin does, so pull it in directly. -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.27.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>${version.maven.plugin.plugin}</version>
+                <configuration>
+                    <goalPrefix>glassfish-pool</goalPrefix>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/glassfish-pool-maven-plugin/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/mojo/AbstractPoolMojo.java
+++ b/glassfish-pool-maven-plugin/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/mojo/AbstractPoolMojo.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool.mojo;
+
+import java.io.File;
+import java.nio.file.Path;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import ee.omnifish.arquillian.container.glassfish.pool.PoolConfig;
+
+/**
+ * Shared {@code @Parameter} surface for every glassfish-pool goal — keeps
+ * the per-goal mojos to a few lines each.
+ */
+abstract class AbstractPoolMojo extends AbstractMojo {
+
+    /** Where the pool of slots is laid out. Created if missing. */
+    @Parameter(property = "gf.pool.dir",
+               defaultValue = "${project.build.directory}/pool",
+               required = true)
+    protected File poolDir;
+
+    /**
+     * Source GlassFish install used as the template for slot clones. Required
+     * for the {@code up} and {@code provision} goals; ignored otherwise.
+     */
+    @Parameter(property = "gf.pool.source")
+    protected File poolSource;
+
+    /** Number of slots the {@code up} goal provisions. Default 1. */
+    @Parameter(property = "gf.pool.size", defaultValue = "1")
+    protected int poolSize;
+
+    /** Admin port for slot 1; subsequent slots step by {@link #portStride}. */
+    @Parameter(property = "gf.pool.adminBase", defaultValue = "14848")
+    protected int adminPortBase;
+
+    /** Per-slot port stride. Must be {@code >= 10}. */
+    @Parameter(property = "gf.pool.portStride", defaultValue = "100")
+    protected int portStride;
+
+    /**
+     * Skip this goal entirely. Useful for letting {@code -DskipTests} or
+     * {@code -Dmaven.test.skip} disable the pool lifecycle without removing
+     * the binding.
+     */
+    @Parameter(property = "gf.pool.skip", defaultValue = "false")
+    protected boolean skip;
+
+    protected PoolConfig poolConfig() {
+        Path source = (poolSource == null) ? null : poolSource.toPath();
+        return new PoolConfig(poolDir.toPath(), source, poolSize, adminPortBase, portStride);
+    }
+}

--- a/glassfish-pool-maven-plugin/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/mojo/AbstractStagingPoolMojo.java
+++ b/glassfish-pool-maven-plugin/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/mojo/AbstractStagingPoolMojo.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool.mojo;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+
+import ee.omnifish.arquillian.container.glassfish.pool.ArtifactCoord;
+import ee.omnifish.arquillian.container.glassfish.pool.OverlayCoord;
+import ee.omnifish.arquillian.container.glassfish.pool.PoolStaging;
+import ee.omnifish.arquillian.container.glassfish.pool.StageSpec;
+
+/**
+ * Adds staging configuration on top of {@link AbstractPoolMojo}: which
+ * GlassFish distribution to fetch, which overlay jars to drop into the
+ * staged install, where to unpack. Shared by {@link UpMojo} and
+ * {@link ProvisionMojo}.
+ */
+abstract class AbstractStagingPoolMojo extends AbstractPoolMojo {
+
+    /**
+     * GlassFish distribution to resolve and unpack. When unset, no unpack
+     * happens and {@code gf.pool.source} must already point at a staged install.
+     */
+    @Parameter
+    protected ArtifactCoord distribution;
+
+    /** Where the dist zip is unpacked. Default {@code ${project.build.directory}/dist}. */
+    @Parameter(property = "gf.pool.stageDir", defaultValue = "${project.build.directory}/dist")
+    protected File stageDir;
+
+    /** Skip the dist unpack. Set to {@code true} when reusing an existing install. */
+    @Parameter(property = "gf.pool.unpack.skip", defaultValue = "false")
+    protected boolean unpackSkip;
+
+    /**
+     * Optional artifacts copied into the staged install's modules directory
+     * after unpack. Each {@code <overlay>} is a GAV plus a {@code destFileName}.
+     */
+    @Parameter
+    protected List<OverlayCoord> overlays;
+
+    /**
+     * Where overlay jars land. Defaults to {@code ${gf.pool.source}/glassfish/modules},
+     * which matches the standard GlassFish layout.
+     */
+    @Parameter(property = "gf.pool.overlayTargetDir")
+    protected File overlayTargetDir;
+
+    /** Skip overlays. Set via {@code -Dmojarra.noupdate=true} in TCK builds. */
+    @Parameter(property = "gf.pool.overlay.skip", defaultValue = "false")
+    protected boolean overlaySkip;
+
+    @Component
+    private RepositorySystem repoSystem;
+
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
+    private RepositorySystemSession repoSession;
+
+    @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true, required = true)
+    private List<RemoteRepository> remoteRepos;
+
+    /**
+     * Build the {@code Runnable} that {@link
+     * ee.omnifish.arquillian.container.glassfish.pool.PoolBootstrap#up} runs
+     * inside its provisioning lock. Returns {@code null} if there's no work,
+     * which keeps the provisioning hot-path branch-free.
+     */
+    protected Runnable buildPreStage() throws MojoExecutionException {
+        StageSpec spec = stageSpec();
+        if (!spec.hasWork()) {
+            return null;
+        }
+        return () -> {
+            try {
+                PoolStaging.stage(spec, this::resolveArtifact);
+            } catch (IOException e) {
+                throw new RuntimeException("Pool staging failed: " + e.getMessage(), e);
+            }
+        };
+    }
+
+    private StageSpec stageSpec() {
+        Path overlayDir = (overlayTargetDir != null)
+                ? overlayTargetDir.toPath()
+                : poolSource.toPath().resolve("glassfish/modules");
+        List<OverlayCoord> ov = (overlays == null) ? Collections.emptyList() : overlays;
+        return new StageSpec(stageDir.toPath(), distribution, unpackSkip, overlayDir, ov, overlaySkip);
+    }
+
+    private Path resolveArtifact(ArtifactCoord coord) throws IOException {
+        Artifact aether = new DefaultArtifact(
+                coord.getGroupId(),
+                coord.getArtifactId(),
+                coord.getClassifier(),
+                coord.getType(),
+                coord.getVersion());
+        ArtifactRequest req = new ArtifactRequest(aether, remoteRepos, null);
+        try {
+            return repoSystem.resolveArtifact(repoSession, req).getArtifact().getFile().toPath();
+        } catch (ArtifactResolutionException e) {
+            throw new IOException("Failed to resolve " + coord.toGav() + ": " + e.getMessage(), e);
+        }
+    }
+}

--- a/glassfish-pool-maven-plugin/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/mojo/DownMojo.java
+++ b/glassfish-pool-maven-plugin/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/mojo/DownMojo.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool.mojo;
+
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+
+import ee.omnifish.arquillian.container.glassfish.pool.PoolBootstrap;
+
+/**
+ * Stop every slot's domain. Default phase {@code post-integration-test} so
+ * it pairs with {@link UpMojo}.
+ */
+@Mojo(name = "down", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST, threadSafe = true)
+public class DownMojo extends AbstractPoolMojo {
+
+    @Override
+    public void execute() {
+        if (skip) {
+            getLog().info("glassfish-pool:down skipped (gf.pool.skip=true)");
+            return;
+        }
+        PoolBootstrap.down(poolConfig());
+    }
+}

--- a/glassfish-pool-maven-plugin/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/mojo/NukeMojo.java
+++ b/glassfish-pool-maven-plugin/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/mojo/NukeMojo.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool.mojo;
+
+import java.io.IOException;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+
+import ee.omnifish.arquillian.container.glassfish.pool.PoolBootstrap;
+
+/**
+ * Stop every slot AND remove the pool dir. Forceful reset; the next
+ * {@code up} starts from a clean slate.
+ */
+@Mojo(name = "nuke", threadSafe = true, requiresProject = false)
+public class NukeMojo extends AbstractPoolMojo {
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        try {
+            PoolBootstrap.nuke(poolConfig());
+        } catch (IOException e) {
+            throw new MojoExecutionException("Pool nuke failed: " + e.getMessage(), e);
+        }
+    }
+}

--- a/glassfish-pool-maven-plugin/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/mojo/ProvisionMojo.java
+++ b/glassfish-pool-maven-plugin/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/mojo/ProvisionMojo.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool.mojo;
+
+import java.io.IOException;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import ee.omnifish.arquillian.container.glassfish.pool.PoolBootstrap;
+
+/**
+ * Provision a single extra slot at index {@code -Dgf.pool.slot=N}.
+ *
+ * <p>Useful for ad-hoc additions to an already-running pool. Day-to-day,
+ * {@code SlotLeaser} grows the pool itself when test JVMs need it, so this
+ * goal is mostly a debugging aid.
+ */
+@Mojo(name = "provision", threadSafe = true)
+public class ProvisionMojo extends AbstractStagingPoolMojo {
+
+    @Parameter(property = "gf.pool.slot", required = true)
+    private int slot;
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        if (skip) {
+            getLog().info("glassfish-pool:provision skipped (gf.pool.skip=true)");
+            return;
+        }
+        try {
+            PoolBootstrap.provisionSlot(poolConfig(), slot, buildPreStage());
+        } catch (IOException e) {
+            throw new MojoExecutionException("Slot " + slot + " provisioning failed: " + e.getMessage(), e);
+        }
+    }
+}

--- a/glassfish-pool-maven-plugin/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/mojo/StatusMojo.java
+++ b/glassfish-pool-maven-plugin/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/mojo/StatusMojo.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool.mojo;
+
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import ee.omnifish.arquillian.container.glassfish.pool.PoolBootstrap;
+
+/**
+ * Print one row per slot: index, admin port, alive state, lease state.
+ * Read-only; never modifies pool state.
+ *
+ * <p>On an interactive terminal the table refreshes every {@link #refreshIntervalSeconds}
+ * seconds until Ctrl+C, like {@code top}. When stdout is piped or redirected, or
+ * Maven runs in batch mode ({@code -B}), the table is printed once and the goal
+ * exits — so logs and CI output don't fill with frames. Force one-shot in a TTY
+ * with {@code -Dgf.pool.once}.
+ */
+@Mojo(name = "status", threadSafe = true, requiresProject = false)
+public class StatusMojo extends AbstractPoolMojo {
+
+    /**
+     * Force a single-shot print even on an interactive terminal. Useful when
+     * scripting against the goal from a TTY (e.g. {@code mvn ...:status -Dgf.pool.once | grep ...}).
+     */
+    @Parameter(property = "gf.pool.once", defaultValue = "false")
+    protected boolean once;
+
+    /** Refresh interval in seconds for the live table. Ignored in one-shot mode. */
+    @Parameter(property = "gf.pool.interval", defaultValue = "1")
+    protected int refreshIntervalSeconds;
+
+    /**
+     * Maven's interactive-mode flag. Set to {@code false} by {@code -B} /
+     * {@code --batch-mode} regardless of whether stdout is a TTY, so we use
+     * it to suppress live frames in CI even when CI hands us a real terminal.
+     */
+    @Parameter(defaultValue = "${settings.interactiveMode}", readonly = true)
+    protected boolean interactiveMode;
+
+    @Override
+    public void execute() {
+        if (once || !interactiveMode || System.console() == null) {
+            PoolBootstrap.status(poolConfig());
+        } else {
+            PoolBootstrap.statusWatch(poolConfig(), refreshIntervalSeconds * 1000L);
+        }
+    }
+}

--- a/glassfish-pool-maven-plugin/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/mojo/UpMojo.java
+++ b/glassfish-pool-maven-plugin/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/mojo/UpMojo.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool.mojo;
+
+import java.io.IOException;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import ee.omnifish.arquillian.container.glassfish.pool.PoolBootstrap;
+
+/**
+ * Provision and start every slot. Default phase {@code pre-integration-test}
+ * so it composes naturally with maven-failsafe-plugin.
+ *
+ * <p>Skips when {@code -DskipTests} or {@code -Dmaven.test.skip} is set: if
+ * the build isn't running tests, there's no reason to pay for a pool.
+ */
+@Mojo(name = "up", defaultPhase = LifecyclePhase.PRE_INTEGRATION_TEST, threadSafe = true)
+public class UpMojo extends AbstractStagingPoolMojo {
+
+    @Parameter(property = "skipTests", defaultValue = "false")
+    protected boolean skipTests;
+
+    @Parameter(property = "maven.test.skip", defaultValue = "false")
+    protected boolean mavenTestSkip;
+
+    @Override
+    public void execute() throws MojoExecutionException {
+        if (skip) {
+            getLog().info("glassfish-pool:up skipped (gf.pool.skip=true)");
+            return;
+        }
+        if (skipTests) {
+            getLog().info("glassfish-pool:up skipped (-DskipTests)");
+            return;
+        }
+        if (mavenTestSkip) {
+            getLog().info("glassfish-pool:up skipped (-Dmaven.test.skip)");
+            return;
+        }
+        try {
+            PoolBootstrap.up(poolConfig(), buildPreStage());
+        } catch (IOException e) {
+            throw new MojoExecutionException("Pool up failed: " + e.getMessage(), e);
+        }
+    }
+}

--- a/glassfish-pool/README.md
+++ b/glassfish-pool/README.md
@@ -1,0 +1,280 @@
+# Arquillian Container GlassFish Pool
+
+A pool of pre-started GlassFish instances (slots) that Arquillian test JVMs
+lease for the duration of a single JVM run. Designed for parallel builds (e.g.
+`mvn -T 4`): each forked test JVM grabs an idle slot, runs its deployments
+against that slot's DAS, and releases the lock when the JVM exits.
+
+Provisioning, starting, stopping and the lease protocol are pure Java — no
+shell scripts, no `-javaagent`, no surefire `argLine` plumbing. Pool lifecycle
+is normally driven by the [`glassfish-pool-maven-plugin`](../glassfish-pool-maven-plugin/);
+this module ships the runtime types that the test JVM needs in order to lease
+and use a slot.
+
+| Coordinates  | Value                                          |
+| ------------ | ---------------------------------------------- |
+| `groupId`    | `ee.omnifish.arquillian`                       |
+| `artifactId` | `arquillian-glassfish-server-pool`             |
+| Java         | 11+                                            |
+| Arquillian   | Jakarta protocol (`Servlet 5.0`)               |
+
+## When to use this
+
+- You have many Arquillian tests and want to fan them out across cores.
+- You don't want each test class to pay the GlassFish cold-start cost.
+- You want a single pre-warmed install (or N installs) that survives across
+  forked JVMs within a single `mvn` invocation.
+
+If you only need a single, JVM-lifetime-scoped GlassFish, use
+`arquillian-glassfish-server-managed` instead — this pool module exists to
+amortise startup cost across parallel forks.
+
+## Architecture in 30 seconds
+
+1. **Provisioning** clones a source GlassFish install into `slot-1/`,
+   `slot-2/`, … under `poolDir`. Each slot's `domain.xml` is rewritten so its
+   admin/http/https/etc. ports land in a non-overlapping window
+   (`adminBase + (slot - 1) * portStride`).
+2. **Lease** is an exclusive `FileChannel.tryLock()` on `slot-N/lock`. The
+   slot's coordinates are published in `slot-N/ports.properties`, written
+   only after `start-domain` succeeds.
+3. **Test JVM** picks an idle slot (least-recently-used wins), reads its
+   ports, hands them to `CommonGlassFishManager`, deploys via REST, releases
+   the lock at JVM shutdown.
+
+```
+poolDir/
+├── grow.lock                        # serialises pool-grow across JVMs
+├── slot-1/
+│   ├── lock                         # FileLock holds the slot
+│   ├── ports.properties             # adminPort, httpPort, httpsPort, glassFishHome
+│   └── glassfish9/                  # the cloned install
+├── slot-2/
+│   └── ...
+└── ...
+```
+
+## Test-JVM consumer setup
+
+Add the pool container as a `test`-scope dependency:
+
+```xml
+<dependency>
+    <groupId>ee.omnifish.arquillian</groupId>
+    <artifactId>arquillian-glassfish-server-pool</artifactId>
+    <version>2.1.4</version>
+    <scope>test</scope>
+</dependency>
+```
+
+…and an `arquillian.xml` that points at the same `poolDir` the build is
+provisioning into:
+
+```xml
+<arquillian xmlns="http://jboss.org/schema/arquillian"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian
+                                https://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <container qualifier="glassfish-pool" default="true">
+        <configuration>
+            <property name="poolDir">${project.build.directory}/pool</property>
+            <property name="leaseTimeoutSeconds">120</property>
+        </configuration>
+    </container>
+</arquillian>
+```
+
+`poolDir` may also be supplied as a system property (`-Dgf.pool.dir=...`),
+which is what the integration tests do — see [`integration-tests/src/it/pool`](../integration-tests/src/it/pool).
+
+## End-to-end Maven setup
+
+Wiring the pool into a build is three plugin blocks: stage GlassFish, run
+`glassfish-pool:up` before `failsafe:integration-test`, forward `gf.pool.dir`
+to the test JVMs.
+
+```xml
+<properties>
+    <glassfish.version>9.0.0</glassfish.version>
+    <pool.size>4</pool.size>
+</properties>
+
+<build>
+    <plugins>
+        <!-- 1. Unpack a GlassFish dist; the pool will clone from this. -->
+        <plugin>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+                <execution>
+                    <id>unpack-glassfish</id>
+                    <phase>process-test-classes</phase>
+                    <goals><goal>unpack</goal></goals>
+                    <configuration>
+                        <artifactItems>
+                            <artifactItem>
+                                <groupId>org.glassfish.main.distributions</groupId>
+                                <artifactId>glassfish</artifactId>
+                                <version>${glassfish.version}</version>
+                                <type>zip</type>
+                                <outputDirectory>${project.build.directory}/dist</outputDirectory>
+                            </artifactItem>
+                        </artifactItems>
+                    </configuration>
+                </execution>
+            </executions>
+        </plugin>
+
+        <!-- 2. Provision/start the pool before failsafe; tear it down after. -->
+        <plugin>
+            <groupId>ee.omnifish.arquillian</groupId>
+            <artifactId>glassfish-pool-maven-plugin</artifactId>
+            <version>2.1.4</version>
+            <configuration>
+                <poolDir>${project.build.directory}/pool</poolDir>
+                <poolSource>${project.build.directory}/dist/glassfish9</poolSource>
+                <poolSize>${pool.size}</poolSize>
+            </configuration>
+            <executions>
+                <execution><id>pool-up</id><goals><goal>up</goal></goals></execution>
+                <execution><id>pool-down</id><goals><goal>down</goal></goals></execution>
+            </executions>
+        </plugin>
+
+        <!-- 3. Forward gf.pool.dir to test JVMs, run tests in parallel forks. -->
+        <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+                <forkCount>${pool.size}</forkCount>
+                <reuseForks>true</reuseForks>
+                <systemPropertyVariables>
+                    <gf.pool.dir>${project.build.directory}/pool</gf.pool.dir>
+                </systemPropertyVariables>
+            </configuration>
+            <executions>
+                <execution>
+                    <goals><goal>integration-test</goal><goal>verify</goal></goals>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
+</build>
+```
+
+Run it:
+
+```
+mvn verify
+```
+
+For per-class fork parallelism across `${pool.size}` slots, that's all you
+need. To go wider than `${pool.size}`, see *Growing on demand* below.
+
+## Configuration reference
+
+### Test-JVM configuration (`arquillian.xml` properties)
+
+| Property              | Type   | Default                  | Notes                                                   |
+| --------------------- | ------ | ------------------------ | ------------------------------------------------------- |
+| `poolDir`             | String | `-Dgf.pool.dir`          | Required. Must match the build's `poolDir`.             |
+| `leaseTimeoutSeconds` | long   | `600`                    | Lease wait before failing the test JVM.                 |
+| `adminUser`           | String | `admin`                  | Inherited from `CommonGlassFishConfiguration`.          |
+| `adminPassword`       | String | (empty)                  | Inherited.                                              |
+| `httpPort`            | int    | overwritten at lease     | Set from the slot's `ports.properties`.                 |
+| `httpsPort`           | int    | overwritten at lease     | Set from the slot's `ports.properties`.                 |
+| `glassFishHome`       | String | overwritten at lease     | Set from the slot's `ports.properties`.                 |
+
+`adminHost`/`adminPort` are also overwritten at lease time. Anything you set
+in `arquillian.xml` for those four host/port fields is informational only —
+the leased slot wins.
+
+### System properties forwarded by the build
+
+These configure the pool layout. The Maven plugin sets them automatically;
+you only need them if you're driving lifecycle from antrun, an IDE, or a
+shell script.
+
+| System property        | Default | Meaning                                                |
+| ---------------------- | ------- | ------------------------------------------------------ |
+| `gf.pool.dir`          | (req)   | Pool root directory.                                   |
+| `gf.pool.source`       | (none)  | Source GlassFish install (template for slot clones).   |
+| `gf.pool.size`         | `1`     | Initial number of slots `up` provisions.               |
+| `gf.pool.adminBase`    | `14848` | Admin port for slot 1.                                 |
+| `gf.pool.portStride`   | `100`   | Per-slot port spacing. Must be ≥ 10.                   |
+
+Slot N's admin port = `adminBase + (N-1) * portStride`; HTTP/HTTPS land at
+`+1` and `+2`. The other GlassFish ports (JMX, IIOP, …) are placed within the
+same window by `DomainXmlEditor`.
+
+## Growing on demand (optional)
+
+If `gf.pool.source` is forwarded to test JVMs, `SlotLeaser` will provision a
+new slot when every existing slot is busy and the wait would otherwise
+deadlock. To enable, add to `failsafe`'s `<systemPropertyVariables>`:
+
+```xml
+<gf.pool.source>${project.build.directory}/dist/glassfish9</gf.pool.source>
+<gf.pool.adminBase>14848</gf.pool.adminBase>
+<gf.pool.portStride>100</gf.pool.portStride>
+```
+
+Without `gf.pool.source` the leaser still works against the existing pool —
+it just blocks for an idle slot instead of growing one. That's the right
+default when `forkCount` ≤ `poolSize`.
+
+## Programmatic use
+
+The lifecycle API is in `PoolBootstrap`. Useful when wiring from JUnit
+extensions, gradle, or one-off scripts:
+
+```java
+PoolConfig config = new PoolConfig(
+        Paths.get("target/pool"),                  // poolDir
+        Paths.get("target/dist/glassfish9"),       // source install
+        4,                                         // size
+        PoolConfig.DEFAULT_ADMIN_BASE,             // 14848
+        PoolConfig.DEFAULT_PORT_STRIDE);           // 100
+
+PoolBootstrap.up(config);                          // provision + start, parallel
+// ... run things against the pool ...
+PoolBootstrap.down(config);                        // stop every slot
+```
+
+`up()` is idempotent: repeated calls fast-exit if every slot already has a
+healthy admin port. A JVM shutdown hook calls `down()` when the JVM exits
+normally or via Ctrl+C.
+
+For ad-hoc lease use:
+
+```java
+SlotLeaser leaser = new SlotLeaser(config, /* timeoutSeconds */ 120);
+try (SlotLease lease = leaser.lease()) {
+    SlotPorts ports = lease.ports();
+    // ports.adminPort(), ports.httpPort(), ports.httpsPort(), ports.glassFishHome()
+}
+```
+
+## Troubleshooting
+
+- **`Could not lease a GlassFish pool slot within Ns`** — every slot is busy
+  and growing is disabled (or failed). Increase `leaseTimeoutSeconds`,
+  reduce `forkCount`, or wire `gf.pool.source` so the leaser can grow.
+- **`poolDir is required`** — `arquillian.xml` is missing `<property
+  name="poolDir">` and `-Dgf.pool.dir` isn't set. The test JVM doesn't know
+  where to look.
+- **Slot `alive=no` in `glassfish-pool:status`** — the slot's GlassFish died
+  (OOM, killed). The leaser will recycle it on next grow if `gf.pool.source`
+  is set; otherwise run `mvn glassfish-pool:nuke` then `:up`.
+- **`portStride must be >= 10`** — a GlassFish domain uses ~10 ports;
+  smaller strides collide.
+- **Two `mvn` invocations stomp on each other** — JVM-wide locks only protect
+  one Maven run. Use distinct `poolDir`s (or distinct `adminBase`s) for
+  parallel `mvn` invocations on the same machine.
+
+## Related modules
+
+- [`glassfish-pool-maven-plugin`](../glassfish-pool-maven-plugin/) — Maven
+  goals (`up`, `down`, `provision`, `status`, `nuke`) wrapping this module.
+- [`integration-tests/src/it/pool`](../integration-tests/src/it/pool) —
+  end-to-end smoke test that exercises both modules.
+- `arquillian-glassfish-server-managed` — single-JVM-scoped GlassFish, no pool.

--- a/glassfish-pool/pom.xml
+++ b/glassfish-pool/pom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+  See the License for the specific
+  language governing permissions and limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ee.omnifish.arquillian</groupId>
+        <artifactId>glassfish-containers-dependencies</artifactId>
+        <version>2.1.4-SNAPSHOT</version>
+        <relativePath>../dependencies</relativePath>
+    </parent>
+
+    <artifactId>arquillian-glassfish-server-pool</artifactId>
+
+    <name>Arquillian Container GlassFish Pool</name>
+    <description>
+        Pool of pre-started GlassFish instances. Test JVMs running in parallel (e.g. via
+        Maven -T) lease an idle slot for the duration of the JVM and run their Arquillian
+        deployments against it. Provisioning, starting, stopping and the lease protocol
+        are pure Java; no shell scripts.
+    </description>
+
+    <properties>
+        <!--
+            The parent pom defaults this to GlassFish's JUL extension, which is only
+            on the classpath of modules that pull in the embedded GlassFish dist.
+            Pool unit tests are pure JUnit, so fall back to the JDK default and avoid
+            the surefire CNFE on LogManager bootstrap.
+        -->
+        <test.logManager>java.util.logging.LogManager</test.logManager>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>ee.omnifish.arquillian</groupId>
+            <artifactId>glassfish-container-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Used by PoolStaging to preserve POSIX permissions when unzipping.
+             Optional because only the Maven plugin calls PoolStaging; test-JVM
+             consumers of this jar pull in just the runtime types. -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.27.1</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.protocol</groupId>
+            <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.testenricher</groupId>
+            <artifactId>arquillian-testenricher-cdi-jakarta</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.testenricher</groupId>
+            <artifactId>arquillian-testenricher-ejb-jakarta</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.testenricher</groupId>
+            <artifactId>arquillian-testenricher-resource-jakarta</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.testenricher</groupId>
+            <artifactId>arquillian-testenricher-initialcontext</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/ArtifactCoord.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/ArtifactCoord.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+/**
+ * Maven artifact coordinate carried through the staging pipeline.
+ *
+ * <p>Mutable JavaBean shape so Plexus can inject mojo configuration (nested
+ * {@code <distribution>} block) by setter. {@link PoolStaging} treats it as
+ * read-only after construction.
+ */
+public class ArtifactCoord {
+
+    private String groupId;
+    private String artifactId;
+    private String version;
+    private String type = "jar";
+    private String classifier;
+
+    public ArtifactCoord() {
+    }
+
+    public ArtifactCoord(String groupId, String artifactId, String version, String type, String classifier) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+        this.version = version;
+        this.type = (type == null || type.isEmpty()) ? "jar" : type;
+        this.classifier = classifier;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(String groupId) {
+        this.groupId = groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    public void setArtifactId(String artifactId) {
+        this.artifactId = artifactId;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getClassifier() {
+        return classifier;
+    }
+
+    public void setClassifier(String classifier) {
+        this.classifier = classifier;
+    }
+
+    /** {@code groupId:artifactId:version[:type][:classifier]} for marker comparison and logs. */
+    public String toGav() {
+        StringBuilder sb = new StringBuilder()
+                .append(groupId).append(':').append(artifactId).append(':').append(version);
+        if (type != null && !type.isEmpty() && !"jar".equals(type)) {
+            sb.append(':').append(type);
+        }
+        if (classifier != null && !classifier.isEmpty()) {
+            sb.append(':').append(classifier);
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public String toString() {
+        return toGav();
+    }
+}

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/AsAdmin.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/AsAdmin.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Thin wrapper around {@code glassfish/bin/asadmin}. Used by the provisioner
+ * to run {@code start-domain}/{@code stop-domain} against a per-slot install.
+ *
+ * <p>Acknowledged duplication with managed's {@code GlassFishServerControl};
+ * a follow-up PR can promote this to {@code glassfish-common}.
+ */
+final class AsAdmin {
+
+    private static final Logger LOG = Logger.getLogger(AsAdmin.class.getName());
+
+    private static final String JAVA = System.getProperty("os.name").toLowerCase().contains("win")
+            ? "java.exe"
+            : "java";
+
+    private final Path glassFishHome;
+
+    AsAdmin(Path glassFishHome) {
+        this.glassFishHome = glassFishHome;
+    }
+
+    /**
+     * Run {@code asadmin <command> <args...>}. Output is collected and logged
+     * at the level corresponding to the exit code; {@link AsAdminException}
+     * is thrown with the captured output on non-zero.
+     */
+    void run(String command, String... args) throws AsAdminException {
+        Path asadmin = asadminScript();
+        List<String> cmd = new ArrayList<>();
+        cmd.add(asadmin.toString());
+        cmd.add("--terse");
+        cmd.add(command);
+        cmd.addAll(Arrays.asList(args));
+
+        ProcessBuilder pb = new ProcessBuilder(cmd).redirectErrorStream(true);
+        // Ensure asadmin uses the same JDK as the calling process unless the
+        // user has set AS_JAVA explicitly. asadmin honours AS_JAVA over JAVA_HOME.
+        Path javaHome = Paths.get(System.getProperty("java.home"));
+        pb.environment().putIfAbsent("AS_JAVA", javaHome.toString());
+        pb.environment().putIfAbsent("JAVA_HOME", javaHome.toString());
+
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        int exit;
+        try {
+            Process process = pb.start();
+            // Drain inline: asadmin can write enough to fill the OS pipe buffer,
+            // so consuming after waitFor() risks deadlock. Buffer raw bytes and
+            // decode once to avoid mangling multi-byte chars across read chunks.
+            try (InputStream in = process.getInputStream()) {
+                in.transferTo(buf);
+            }
+            exit = process.waitFor();
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new AsAdminException("asadmin " + command + " failed to run", e);
+        }
+        String out = buf.toString(StandardCharsets.UTF_8);
+        if (exit != 0) {
+            throw new AsAdminException("asadmin " + command + " exit=" + exit + " output:\n" + out);
+        }
+        if (LOG.isLoggable(Level.FINE)) {
+            LOG.fine("asadmin " + command + " ok\n" + out);
+        }
+    }
+
+    private Path asadminScript() {
+        Path script = glassFishHome.resolve("glassfish").resolve("bin").resolve(asadminFile());
+        if (!Files.isRegularFile(script)) {
+            throw new IllegalStateException(
+                    "asadmin not found at " + script + " — is glassFishHome correct?");
+        }
+        return script;
+    }
+
+    private static String asadminFile() {
+        return JAVA.equals("java.exe") ? "asadmin.bat" : "asadmin";
+    }
+
+    static final class AsAdminException extends RuntimeException {
+        private static final long serialVersionUID = 1L;
+
+        AsAdminException(String message) {
+            super(message);
+        }
+
+        AsAdminException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/DomainXmlEditor.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/DomainXmlEditor.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Map;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ * DOM-based editor for the per-slot {@code domain.xml}: rewrites the
+ * {@code port} attribute on the admin/http/https {@code <network-listener>}
+ * elements.
+ *
+ * <p>Writes go through a sibling tmp file + atomic move so the underlying
+ * inode is replaced rather than truncated. That matters because pool slots
+ * are produced by hardlinking the source install ({@code Files.createLink}
+ * per file); truncating in place would also rewrite the source's
+ * {@code domain.xml}, the one that must stay pristine for the next slot.
+ */
+final class DomainXmlEditor {
+
+    private DomainXmlEditor() {
+    }
+
+    /**
+     * Set the admin/http/https ports on the given {@code domain.xml}. Listeners
+     * whose port is already correct or set to a {@code ${...}} placeholder are
+     * left alone.
+     *
+     * @param domainXml path to {@code config/domain.xml}
+     * @param admin admin-listener port
+     * @param http http-listener-1 port
+     * @param https http-listener-2 port
+     * @throws IOException if the file can't be parsed, rewritten, or moved into place
+     */
+    static void setPorts(Path domainXml, int admin, int http, int https) throws IOException {
+        Map<String, Integer> wanted = Map.of(
+                "admin-listener", admin,
+                "http-listener-1", http,
+                "http-listener-2", https);
+
+        Document doc = parse(domainXml);
+        boolean changed = false;
+        NodeList listeners = doc.getElementsByTagName("network-listener");
+        for (int i = 0; i < listeners.getLength(); i++) {
+            Element listener = (Element) listeners.item(i);
+            Integer target = wanted.get(listener.getAttribute("name"));
+            if (target == null) {
+                continue;
+            }
+            String current = listener.getAttribute("port");
+            if (current.startsWith("${") || current.equals(target.toString())) {
+                continue;
+            }
+            listener.setAttribute("port", target.toString());
+            changed = true;
+        }
+        if (!changed) {
+            return;
+        }
+        atomicWrite(domainXml, doc);
+    }
+
+    private static Document parse(Path domainXml) throws IOException {
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        // domain.xml has no namespaces and pulls no external entities; harden
+        // the parser so a tampered file can't trigger XXE or DOCTYPE expansion.
+        try {
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            dbf.setXIncludeAware(false);
+            dbf.setExpandEntityReferences(false);
+            return dbf.newDocumentBuilder().parse(domainXml.toFile());
+        } catch (ParserConfigurationException | SAXException e) {
+            throw new IOException("Could not parse " + domainXml, e);
+        }
+    }
+
+    private static void atomicWrite(Path target, Document doc) throws IOException {
+        Path tmp = target.resolveSibling(target.getFileName() + ".tmp");
+        try {
+            Transformer t = TransformerFactory.newInstance().newTransformer();
+            t.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+            t.transform(new DOMSource(doc), new StreamResult(tmp.toFile()));
+        } catch (TransformerException e) {
+            throw new IOException("Could not serialize " + target, e);
+        }
+        try {
+            Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            // ATOMIC_MOVE is unsupported on some filesystems (e.g. cross-FS, exotic
+            // network mounts). Fall back to a non-atomic replace — still inode-
+            // replacing on POSIX, just not guaranteed crash-safe.
+            Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+}

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolConfiguration.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolConfiguration.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import org.jboss.arquillian.container.spi.ConfigurationException;
+
+import ee.omnifish.arquillian.container.glassfish.CommonGlassFishConfiguration;
+
+/**
+ * Test-JVM-side configuration for the pool container. Extends the common
+ * GlassFish config (REST deploy connection: adminHost/adminPort/auth/etc.)
+ * and adds the few fields the pool needs — including http/https ports and
+ * glassFishHome, which a leased slot will fill in.
+ *
+ * <p>The pool-specific fields:
+ * <ul>
+ *   <li>{@code poolDir} — where the provisioner laid out the slots. Must
+ *       match what the build passed to {@code mvn glassfish-pool:up}.</li>
+ *   <li>{@code leaseTimeoutSeconds} — how long to wait for an idle slot
+ *       before failing the test JVM.</li>
+ * </ul>
+ *
+ * <p>{@code httpPort}/{@code httpsPort}/{@code glassFishHome} are populated
+ * at lease time from the slot's published {@link SlotPorts}; values set here
+ * (or inherited from system properties) are overwritten.
+ *
+ * <p>Doesn't extend {@code GlassFishManagedContainerConfiguration} on
+ * purpose: the managed module's {@code LoadableExtension} would also be
+ * picked up by Arquillian's SPI scan if the managed jar were on the test
+ * classpath, registering a second {@code DeployableContainer} and confusing
+ * container selection. Keeping the pool independent of managed avoids that.
+ */
+public class GlassFishPoolConfiguration extends CommonGlassFishConfiguration {
+
+    private static final long DEFAULT_LEASE_TIMEOUT_SECONDS = 600L;
+
+    private String poolDir = System.getProperty(PoolConfig.SYS_POOL_DIR);
+    private long leaseTimeoutSeconds = Long.parseLong(
+            System.getProperty("gf.pool.leaseTimeoutSeconds", String.valueOf(DEFAULT_LEASE_TIMEOUT_SECONDS)));
+
+    private int httpPort = Integer.parseInt(System.getProperty("glassfish.httpPort", "8080"));
+    private int httpsPort = Integer.parseInt(System.getProperty("glassfish.httpsPort", "8181"));
+    private String glassFishHome = System.getProperty("glassfish.home");
+
+    public String getPoolDir() {
+        return poolDir;
+    }
+
+    public void setPoolDir(String poolDir) {
+        this.poolDir = poolDir;
+    }
+
+    public long getLeaseTimeoutSeconds() {
+        return leaseTimeoutSeconds;
+    }
+
+    public void setLeaseTimeoutSeconds(long leaseTimeoutSeconds) {
+        this.leaseTimeoutSeconds = leaseTimeoutSeconds;
+    }
+
+    public int getHttpPort() {
+        return httpPort;
+    }
+
+    public void setHttpPort(int httpPort) {
+        this.httpPort = httpPort;
+    }
+
+    public int getHttpsPort() {
+        return httpsPort;
+    }
+
+    public void setHttpsPort(int httpsPort) {
+        this.httpsPort = httpsPort;
+    }
+
+    public String getGlassFishHome() {
+        return glassFishHome;
+    }
+
+    public void setGlassFishHome(String glassFishHome) {
+        this.glassFishHome = glassFishHome;
+    }
+
+    @Override
+    public void validate() throws ConfigurationException {
+        if (poolDir == null || poolDir.isEmpty()) {
+            throw new ConfigurationException(
+                    "poolDir is required (set <property name=\"poolDir\"> in arquillian.xml or "
+                    + "system property " + PoolConfig.SYS_POOL_DIR + ")");
+        }
+    }
+}

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolDeployableContainer.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolDeployableContainer.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
+import org.jboss.arquillian.container.spi.client.container.DeploymentException;
+import org.jboss.arquillian.container.spi.client.container.LifecycleException;
+import org.jboss.arquillian.container.spi.client.protocol.ProtocolDescription;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptor;
+
+import ee.omnifish.arquillian.container.glassfish.CommonGlassFishManager;
+
+/**
+ * Test-JVM-side container: leases a pre-started slot at {@link #setup} time,
+ * writes the leased ports into the inherited config, then deploys via the
+ * standard {@link CommonGlassFishManager} (REST against the slot's DAS).
+ *
+ * <p>Replaces the {@code -javaagent} + system-property side-channel approach
+ * the Faces TCK used: leasing happens through the Arquillian container
+ * lifecycle, so no premain hook and no surefire {@code argLine} plumbing.
+ *
+ * <h2>Why {@link #start} reads pool layout from system properties</h2>
+ * Pool slots run on different ports (admin/http/https are offset per slot via
+ * {@code adminBase} + {@code portStride}), and the source install path is a
+ * build-time concern, not a per-test-class concern. These values must be set
+ * once for the build and inherited by every test JVM — arquillian.xml is the
+ * wrong layer because it would force every consumer to repeat the same values
+ * in every container element. Surefire/failsafe forwards them as system
+ * properties ({@link PoolConfig#SYS_SOURCE}, {@link PoolConfig#SYS_ADMIN_BASE},
+ * {@link PoolConfig#SYS_PORT_STRIDE}); arquillian.xml only carries the
+ * test-JVM concerns ({@code poolDir}, {@code leaseTimeoutSeconds}). If the
+ * sysprops are absent the leaser still works against an existing pool — it
+ * just can't grow new slots, which is fine for fixed-size pre-provisioned
+ * pools and only matters when {@code -TN} > {@code pool.size}.
+ */
+public class GlassFishPoolDeployableContainer implements DeployableContainer<GlassFishPoolConfiguration> {
+
+    private static final Logger LOG = Logger.getLogger(GlassFishPoolDeployableContainer.class.getName());
+
+    private GlassFishPoolConfiguration configuration;
+    private CommonGlassFishManager<GlassFishPoolConfiguration> manager;
+    private SlotLease lease;
+
+    @Override
+    public Class<GlassFishPoolConfiguration> getConfigurationClass() {
+        return GlassFishPoolConfiguration.class;
+    }
+
+    @Override
+    public ProtocolDescription getDefaultProtocol() {
+        return new ProtocolDescription("Servlet 5.0");
+    }
+
+    @Override
+    public void setup(GlassFishPoolConfiguration configuration) {
+        if (configuration == null) {
+            throw new IllegalArgumentException("configuration must not be null");
+        }
+        this.configuration = configuration;
+    }
+
+    @Override
+    public void start() throws LifecycleException {
+        // Lease at start() rather than setup() because Arquillian calls
+        // setup() on every container in arquillian.xml during context init,
+        // even those not selected; lease only when the container is being
+        // started for actual use.
+        Path poolDir = Paths.get(configuration.getPoolDir());
+        // Source / port layout come from system properties (forwarded by
+        // surefire/failsafe) — see class Javadoc for the rationale.
+        PoolConfig poolConfig = new PoolConfig(
+                poolDir,
+                pathOrNull(System.getProperty(PoolConfig.SYS_SOURCE)),
+                0,
+                Integer.getInteger(PoolConfig.SYS_ADMIN_BASE, PoolConfig.DEFAULT_ADMIN_BASE),
+                Integer.getInteger(PoolConfig.SYS_PORT_STRIDE, PoolConfig.DEFAULT_PORT_STRIDE));
+        SlotLeaser leaser = new SlotLeaser(poolConfig, configuration.getLeaseTimeoutSeconds());
+        try {
+            lease = leaser.lease();
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new LifecycleException("Could not lease a pool slot", e);
+        }
+        SlotPorts ports = lease.ports();
+        configuration.setAdminHost("localhost");
+        configuration.setAdminPort(ports.adminPort());
+        configuration.setHttpPort(ports.httpPort());
+        configuration.setHttpsPort(ports.httpsPort());
+        configuration.setGlassFishHome(ports.glassFishHome());
+
+        LOG.info("Leased pool slot " + lease.slotIndex()
+                + " (adminPort=" + ports.adminPort() + ")");
+
+        manager = new CommonGlassFishManager<>(configuration);
+        manager.start();
+    }
+
+    @Override
+    public void stop() throws LifecycleException {
+        if (lease == null) {
+            return;
+        }
+        try {
+            lease.close();
+        } catch (RuntimeException e) {
+            LOG.log(Level.WARNING, "Releasing slot lease " + lease.slotIndex() + " failed", e);
+        } finally {
+            lease = null;
+            manager = null;
+        }
+    }
+
+    @Override
+    public ProtocolMetaData deploy(Archive<?> archive) throws DeploymentException {
+        return manager.deploy(archive);
+    }
+
+    @Override
+    public void undeploy(Archive<?> archive) throws DeploymentException {
+        manager.undeploy(archive);
+    }
+
+    @Override
+    public void deploy(Descriptor descriptor) throws DeploymentException {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public void undeploy(Descriptor descriptor) throws DeploymentException {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    private static Path pathOrNull(String s) {
+        return (s == null || s.isEmpty()) ? null : Paths.get(s);
+    }
+}

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolExtension.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolExtension.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+/**
+ * Registers {@link GlassFishPoolDeployableContainer} as the Arquillian
+ * {@link DeployableContainer} implementation. Picked up via the
+ * {@code META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension}
+ * descriptor on the classpath.
+ */
+public class GlassFishPoolExtension implements LoadableExtension {
+
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(DeployableContainer.class, GlassFishPoolDeployableContainer.class);
+    }
+}

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/OverlayCoord.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/OverlayCoord.java
@@ -19,6 +19,7 @@ package ee.omnifish.arquillian.container.glassfish.pool;
 public class OverlayCoord extends ArtifactCoord {
 
     private String destFileName;
+    private boolean skip;
 
     public OverlayCoord() {
     }
@@ -35,5 +36,13 @@ public class OverlayCoord extends ArtifactCoord {
 
     public void setDestFileName(String destFileName) {
         this.destFileName = destFileName;
+    }
+
+    public boolean isSkip() {
+        return skip;
+    }
+
+    public void setSkip(boolean skip) {
+        this.skip = skip;
     }
 }

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/OverlayCoord.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/OverlayCoord.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+/**
+ * Single overlay artifact: an {@link ArtifactCoord} plus the file name it
+ * should land under in the staged install's {@code modules/} directory.
+ *
+ * <p>JavaBean for Plexus injection (nested {@code <overlay>} blocks).
+ */
+public class OverlayCoord extends ArtifactCoord {
+
+    private String destFileName;
+
+    public OverlayCoord() {
+    }
+
+    public OverlayCoord(String groupId, String artifactId, String version, String type, String classifier,
+                        String destFileName) {
+        super(groupId, artifactId, version, type, classifier);
+        this.destFileName = destFileName;
+    }
+
+    public String getDestFileName() {
+        return destFileName;
+    }
+
+    public void setDestFileName(String destFileName) {
+        this.destFileName = destFileName;
+    }
+}

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolBootstrap.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolBootstrap.java
@@ -1,0 +1,439 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Public Java API used by the Maven plugin's mojos and by direct
+ * {@code <java>} antrun invocations. Three operations:
+ * <ul>
+ *   <li>{@link #up} — provision N slots in parallel, start their domains,
+ *       arm a JVM shutdown hook so {@code Ctrl+C} doesn't orphan them.</li>
+ *   <li>{@link #down} — stop every slot's domain.</li>
+ *   <li>{@link #provisionSlot} — bootstrap one extra slot at a given index
+ *       (used by {@link SlotLeaser} when growing the pool on demand).</li>
+ * </ul>
+ *
+ * <p>For one-off invocations from antrun's {@code <java>} task, {@link #main}
+ * dispatches the same operations from system properties (so the consumer
+ * pom passes everything via {@code <sysproperty>}).
+ */
+public final class PoolBootstrap {
+
+    private static final Logger LOG = Logger.getLogger(PoolBootstrap.class.getName());
+
+    // ANSI colors used for the [LIVE] tag — mirrors ProgressListener's [RUNNING]/[FAILED] styling.
+    private static final String WHITE = "[37m";
+    private static final String BOLD_GREEN = "[1;32m";
+    private static final String RESET = "[0m";
+
+    /**
+     * Cap on parallel slot workers. Cold-start of a GlassFish domain is
+     * dominated by JVM warmup and disk IO; beyond ~16 concurrent starts the
+     * host's IO/CPU saturates and total wall-clock stops improving (and
+     * regresses on smaller machines). Only relevant if {@link PoolConfig#size}
+     * exceeds this — otherwise the executor sizes itself to the slot count.
+     */
+    private static final int MAX_PROVISION_PARALLELISM = 16;
+
+    private static final AtomicBoolean shutdownHookInstalled = new AtomicBoolean(false);
+
+    /**
+     * Serialises concurrent {@link #up} calls within a single JVM so two
+     * threads cannot race on cloning and {@code start-domain} for the same
+     * slot. Cross-JVM callers must coordinate externally — the lock is
+     * JVM-wide only.
+     */
+    private static final Object UP_LOCK = new Object();
+
+    private PoolBootstrap() {
+    }
+
+    /**
+     * Provision and start {@code config.size()} slots. Existing healthy slots
+     * are left alone (the underlying {@link PoolProvisioner#provisionSlot} is
+     * idempotent), so this is safe to re-run after a partial failure.
+     *
+     * <p>Provisioning is parallel: each slot's clone + start-domain runs on
+     * its own thread, so cold-start time scales with the slowest slot rather
+     * than the sum.
+     */
+    public static void up(PoolConfig config) throws IOException {
+        up(config, null);
+    }
+
+    /**
+     * Variant that runs a caller-supplied staging step inside the same
+     * {@code UP_LOCK} window, before the "already provisioned?" fast-path.
+     * The Maven plugin uses this to resolve + unpack the GlassFish dist and
+     * overlay artifacts before slot provisioning runs.
+     */
+    public static void up(PoolConfig config, Runnable preStage) throws IOException {
+        synchronized (UP_LOCK) {
+            Files.createDirectories(config.poolDir());
+            installShutdownHook(config);
+            if (preStage != null) {
+                preStage.run();
+            }
+            if (config.size() <= 0) {
+                LOG.info("Pool size is 0 — nothing to provision");
+                return;
+            }
+            if (isAlreadyProvisioned(config)) {
+                LOG.fine("Pool already healthy — nothing to do");
+                return;
+            }
+            ExecutorService pool = Executors.newFixedThreadPool(Math.min(config.size(), MAX_PROVISION_PARALLELISM));
+            try {
+                List<CompletableFuture<Void>> futures = new ArrayList<>();
+                PoolProvisioner provisioner = new PoolProvisioner(config);
+                for (int i = 1; i <= config.size(); i++) {
+                    final int slot = i;
+                    futures.add(CompletableFuture.runAsync(() -> {
+                        try {
+                            provisioner.provisionSlot(slot);
+                        } catch (IOException e) {
+                            throw new RuntimeException("Slot " + slot + " provisioning failed", e);
+                        }
+                    }, pool));
+                }
+                CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+            } finally {
+                pool.shutdown();
+            }
+            LOG.info("Pool ready at " + config.poolDir() + " with " + config.size() + " slot(s)");
+        }
+    }
+
+    /**
+     * Pool is "already provisioned" when every requested slot has a
+     * {@code ports.properties} pointing at a live admin port. Used by
+     * {@link #up} to fast-exit on a second concurrent (or repeated) call so
+     * the heavy clone/start-domain work isn't re-run.
+     */
+    private static boolean isAlreadyProvisioned(PoolConfig config) {
+        for (int idx = 1; idx <= config.size(); idx++) {
+            java.nio.file.Path portsFile = PoolPaths.portsFile(config.poolDir(), idx);
+            if (!java.nio.file.Files.exists(portsFile)) {
+                return false;
+            }
+            try {
+                SlotPorts ports = SlotPorts.readFrom(portsFile);
+                if (!PoolProvisioner.isPortHealthy(ports.adminPort())) {
+                    return false;
+                }
+            } catch (IOException e) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Stop every {@code slot-N} under {@code config.poolDir()}. Best-effort:
+     * dead slots and slots without an install dir are skipped, errors are logged.
+     */
+    public static void down(PoolConfig config) {
+        Path poolDir = config.poolDir();
+        if (!Files.isDirectory(poolDir)) {
+            return;
+        }
+        List<Integer> slots = listSlotIndices(poolDir);
+        if (slots.isEmpty()) {
+            return;
+        }
+        ExecutorService pool = Executors.newFixedThreadPool(Math.min(slots.size(), MAX_PROVISION_PARALLELISM));
+        try {
+            PoolProvisioner provisioner = new PoolProvisioner(config);
+            List<CompletableFuture<Void>> futures = new ArrayList<>();
+            for (int slot : slots) {
+                futures.add(CompletableFuture.runAsync(() -> provisioner.stopSlot(slot), pool));
+            }
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+        } finally {
+            pool.shutdown();
+        }
+    }
+
+    /**
+     * Provision a single slot. Used by {@link SlotLeaser#tryGrow} and exposed
+     * via the {@code provision} mojo for ad-hoc additions.
+     */
+    public static SlotPorts provisionSlot(PoolConfig config, int idx) throws IOException {
+        return provisionSlot(config, idx, null);
+    }
+
+    /**
+     * Variant that runs an optional staging step inside {@code UP_LOCK} before
+     * provisioning, mirroring {@link #up(PoolConfig, Runnable)}.
+     */
+    public static SlotPorts provisionSlot(PoolConfig config, int idx, Runnable preStage) throws IOException {
+        synchronized (UP_LOCK) {
+            Files.createDirectories(config.poolDir());
+            if (preStage != null) {
+                preStage.run();
+            }
+            return new PoolProvisioner(config).provisionSlot(idx);
+        }
+    }
+
+    /** Print a one-line-per-slot status to stdout: idx, adminPort, alive/dead, leased/idle. */
+    public static void status(PoolConfig config) {
+        status(config, System.out);
+    }
+
+    /**
+     * Variant that writes to a caller-supplied stream. {@link #statusWatch} uses this
+     * to capture each frame into a buffer so it can count rows for the redraw escape.
+     */
+    public static void status(PoolConfig config, PrintStream out) {
+        Path poolDir = config.poolDir();
+        if (!Files.isDirectory(poolDir)) {
+            out.println("Pool dir does not exist: " + poolDir);
+            return;
+        }
+        List<Integer> slots = listSlotIndices(poolDir);
+        if (slots.isEmpty()) {
+            out.println("Pool dir " + poolDir + " is empty");
+            return;
+        }
+        // Markdown-pipe table; widths match the longest expected value per column
+        // (alive padded to 10 for breathing room around "bootstrap"; adminPort
+        // 9 covers a 5-digit port and "(io err)").
+        String rowFormat = "| %-4s | %-9s | %-10s | %-6s |%n";
+        out.printf(rowFormat, "slot", "adminPort", "alive", "leased");
+        out.println("|------|-----------|------------|--------|");
+        for (int slot : slots) {
+            Path portsFile = PoolPaths.portsFile(poolDir, slot);
+            String adminPort = "?";
+            String alive = "?";
+            String leased;
+            boolean lockBusy = isLockBusy(poolDir, slot);
+            if (Files.exists(portsFile)) {
+                try {
+                    SlotPorts ports = SlotPorts.readFrom(portsFile);
+                    adminPort = String.valueOf(ports.adminPort());
+                    alive = PoolProvisioner.isPortHealthy(ports.adminPort()) ? "yes" : "no";
+                } catch (IOException e) {
+                    adminPort = "(io err)";
+                }
+            } else {
+                alive = lockBusy ? "bootstrap" : "orphan";
+            }
+            leased = lockBusy ? "yes" : "no";
+            out.printf(rowFormat, slot, adminPort, alive, leased);
+        }
+    }
+
+    /**
+     * Live-refreshing variant of {@link #status}: redraws the table every
+     * {@code intervalMs} milliseconds until the JVM is interrupted (Ctrl+C).
+     *
+     * <p>Frame redraw is anchored on the previous frame's line count: cursor
+     * up by that many lines, then per-line clear-to-EOL during reprint, then
+     * a tail clear-to-end-of-screen iff the new frame is shorter. The Maven
+     * banner above the first frame stays untouched.
+     */
+    public static void statusWatch(PoolConfig config, long intervalMs) {
+        int previousLines = 0;
+        // Leading \033[K wipes the line in place as it's rewritten; lets the
+        // redraw stay non-blank instead of erasing then reprinting.
+        String linePrefix = "\033[K" + WHITE + "[" + BOLD_GREEN + "LIVE" + WHITE + "]" + RESET + " ";
+        while (true) {
+            ByteArrayOutputStream buf = new ByteArrayOutputStream();
+            PrintStream framePrinter = new PrintStream(buf, false, StandardCharsets.UTF_8);
+            status(config, framePrinter);
+            framePrinter.println();
+            framePrinter.println("Refreshing every " + (intervalMs / 1000) + "s — press Ctrl+C to exit");
+            framePrinter.flush();
+            String frame = prefixEveryLine(buf.toString(StandardCharsets.UTF_8), linePrefix);
+            if (previousLines > 0) {
+                System.out.print("\033[" + previousLines + "A");
+            }
+            System.out.print(frame);
+            int currentLines = countLines(frame);
+            if (currentLines < previousLines) {
+                // Erase rows beyond the new frame so a shorter frame doesn't
+                // leave old slot rows visible underneath.
+                System.out.print("\033[J");
+            }
+            System.out.flush();
+            previousLines = currentLines;
+            try {
+                Thread.sleep(intervalMs);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+
+    /**
+     * Prepend {@code prefix} to every line in {@code text}. The trailing newline
+     * after the last content line is preserved without spawning a phantom empty
+     * prefixed line at the end.
+     */
+    private static String prefixEveryLine(String text, String prefix) {
+        StringBuilder out = new StringBuilder(text.length() + prefix.length() * 16);
+        int start = 0;
+        for (int i = 0; i < text.length(); i++) {
+            if (text.charAt(i) == '\n') {
+                out.append(prefix).append(text, start, i).append('\n');
+                start = i + 1;
+            }
+        }
+        if (start < text.length()) {
+            out.append(prefix).append(text, start, text.length());
+        }
+        return out.toString();
+    }
+
+    private static int countLines(String text) {
+        int count = 0;
+        for (int i = 0; i < text.length(); i++) {
+            if (text.charAt(i) == '\n') {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /** Stop everything and remove the pool dir entirely. Forceful reset. */
+    public static void nuke(PoolConfig config) throws IOException {
+        down(config);
+        Path poolDir = config.poolDir();
+        if (!Files.isDirectory(poolDir)) {
+            return;
+        }
+        try (var entries = Files.walk(poolDir)) {
+            entries.sorted(Comparator.reverseOrder()).forEach(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (IOException ignored) {
+                    /* best-effort */
+                }
+            });
+        }
+    }
+
+    /**
+     * Antrun-friendly entrypoint. Reads {@link PoolConfig#fromSystemProperties}
+     * and dispatches on the first arg: {@code up}, {@code down}, {@code status},
+     * {@code nuke}, or {@code provision <idx>}.
+     */
+    public static void main(String[] args) throws IOException {
+        if (args.length == 0) {
+            System.err.println("usage: PoolBootstrap up|down|status|nuke|provision <idx>");
+            System.exit(1);
+        }
+        PoolConfig config = PoolConfig.fromSystemProperties();
+        switch (args[0]) {
+            case "up":
+                up(config);
+                break;
+            case "down":
+                down(config);
+                break;
+            case "status":
+                status(config);
+                break;
+            case "nuke":
+                nuke(config);
+                break;
+            case "provision":
+                if (args.length < 2) {
+                    throw new IllegalArgumentException("provision requires <idx>");
+                }
+                provisionSlot(config, Integer.parseInt(args[1]));
+                break;
+            default:
+                System.err.println("Unknown command: " + args[0]);
+                System.exit(1);
+        }
+    }
+
+    /**
+     * Arm a JVM shutdown hook that calls {@link #down}. Set on the JVM that
+     * called {@link #up}, so a Ctrl+C of the Maven process — or a hard build
+     * failure — still releases GlassFish processes. No-op when called outside
+     * a Maven JVM (e.g. inside a forked failsafe JVM, where the test JVM
+     * doesn't own the pool).
+     */
+    private static void installShutdownHook(PoolConfig config) {
+        if (!shutdownHookInstalled.compareAndSet(false, true)) {
+            return;
+        }
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try {
+                down(config);
+            } catch (RuntimeException e) {
+                LOG.log(Level.WARNING, "Pool shutdown hook failed", e);
+            }
+        }, "glassfish-pool-shutdown"));
+    }
+
+    private static List<Integer> listSlotIndices(Path poolDir) {
+        List<Integer> slots = new ArrayList<>();
+        try (var entries = Files.list(poolDir)) {
+            for (Path entry : (Iterable<Path>) entries::iterator) {
+                Integer idx = PoolPaths.slotIndex(entry.getFileName().toString());
+                if (idx != null) {
+                    slots.add(idx);
+                }
+            }
+        } catch (IOException e) {
+            return slots;
+        }
+        slots.sort(Comparator.naturalOrder());
+        return slots;
+    }
+
+    /**
+     * Probe whether the per-slot lock is held by another JVM. Read-only:
+     * never creates the lock file. Status callers may run concurrently with
+     * code that deletes slot dirs, and creating the lock file would both
+     * falsely signal an in-flight bootstrap and resurrect a file inside a
+     * directory being torn down.
+     */
+    private static boolean isLockBusy(Path poolDir, int slot) {
+        Path lockFile = PoolPaths.lockFile(poolDir, slot);
+        if (!Files.exists(lockFile)) {
+            return false;
+        }
+        try (var ch = java.nio.channels.FileChannel.open(lockFile,
+                java.nio.file.StandardOpenOption.READ,
+                java.nio.file.StandardOpenOption.WRITE)) {
+            var probe = ch.tryLock();
+            if (probe == null) {
+                return true;
+            }
+            probe.release();
+            return false;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+}

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolConfig.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolConfig.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+/**
+ * Provisioning-side pool config — used by {@link PoolBootstrap} and the
+ * Maven plugin. The test-JVM-side config (used by the Arquillian extension)
+ * is {@link GlassFishPoolConfiguration}.
+ *
+ * <p>Each slot N occupies a contiguous port window starting at
+ * {@code adminPortBase + N*portStride}. Port stride must be {@code >= 10}
+ * because a GlassFish domain uses 10 ports.
+ */
+public final class PoolConfig {
+
+    /** Default per-slot port stride. 10 ports per domain plus headroom. */
+    public static final int DEFAULT_PORT_STRIDE = 100;
+
+    /** Default starting admin port for slot 1. */
+    public static final int DEFAULT_ADMIN_BASE = 14848;
+
+    private static final int MIN_PORT_STRIDE = 10;
+
+    public static final String SYS_POOL_DIR = "gf.pool.dir";
+    public static final String SYS_SOURCE = "gf.pool.source";
+    public static final String SYS_SIZE = "gf.pool.size";
+    public static final String SYS_ADMIN_BASE = "gf.pool.adminBase";
+    public static final String SYS_PORT_STRIDE = "gf.pool.portStride";
+
+    private final Path poolDir;
+    private final Path source;
+    private final int size;
+    private final int adminPortBase;
+    private final int portStride;
+
+    public PoolConfig(Path poolDir, Path source, int size, int adminPortBase, int portStride) {
+        if (portStride < MIN_PORT_STRIDE) {
+            throw new IllegalArgumentException(
+                    "portStride must be >= " + MIN_PORT_STRIDE + " (got " + portStride + ")");
+        }
+        this.poolDir = Objects.requireNonNull(poolDir, "poolDir");
+        this.source = source;
+        this.size = size;
+        this.adminPortBase = adminPortBase;
+        this.portStride = portStride;
+    }
+
+    public Path poolDir() {
+        return poolDir;
+    }
+
+    /** Source GlassFish install used as the template for slot clones. */
+    public Path source() {
+        return source;
+    }
+
+    public int size() {
+        return size;
+    }
+
+    public int adminPortBase() {
+        return adminPortBase;
+    }
+
+    public int portStride() {
+        return portStride;
+    }
+
+    /** Admin port for slot {@code idx} (1-based). Slot 1 lands on {@link #adminPortBase}. */
+    public int adminPort(int idx) {
+        return adminPortBase + (idx - 1) * portStride;
+    }
+
+    public int httpPort(int idx) {
+        return adminPort(idx) + 1;
+    }
+
+    public int httpsPort(int idx) {
+        return adminPort(idx) + 2;
+    }
+
+    /**
+     * Construct from system properties. Used by {@link PoolBootstrap} so a
+     * Maven antrun {@code <java>} invocation can pass everything via
+     * {@code <sysproperty>} without a CLI dance.
+     */
+    public static PoolConfig fromSystemProperties() {
+        return new PoolConfig(
+                Paths.get(requireSys(SYS_POOL_DIR)),
+                pathOrNull(System.getProperty(SYS_SOURCE)),
+                Integer.parseInt(System.getProperty(SYS_SIZE, "1")),
+                Integer.parseInt(System.getProperty(SYS_ADMIN_BASE, String.valueOf(DEFAULT_ADMIN_BASE))),
+                Integer.parseInt(System.getProperty(SYS_PORT_STRIDE, String.valueOf(DEFAULT_PORT_STRIDE))));
+    }
+
+    private static Path pathOrNull(String s) {
+        return (s == null || s.isEmpty()) ? null : Paths.get(s);
+    }
+
+    private static String requireSys(String key) {
+        String v = System.getProperty(key);
+        if (v == null || v.isEmpty()) {
+            throw new IllegalStateException("System property '" + key + "' is required");
+        }
+        return v;
+    }
+}

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolPaths.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolPaths.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import java.nio.file.Path;
+
+/**
+ * Filesystem layout of a pool. All slot dirs and per-slot files live under
+ * a single {@code poolDir}. Centralised here so callers don't sprinkle
+ * "slot-N" string concatenation across the module.
+ */
+final class PoolPaths {
+
+    static final String SLOT_PREFIX = "slot-";
+    static final String LOCK_FILE = "lock";
+    static final String PORTS_FILE = "ports.properties";
+    static final String GROW_LOCK = "grow.lock";
+
+    private PoolPaths() {
+    }
+
+    static Path slotDir(Path poolDir, int slot) {
+        return poolDir.resolve(SLOT_PREFIX + slot);
+    }
+
+    static Path lockFile(Path poolDir, int slot) {
+        return slotDir(poolDir, slot).resolve(LOCK_FILE);
+    }
+
+    static Path portsFile(Path poolDir, int slot) {
+        return slotDir(poolDir, slot).resolve(PORTS_FILE);
+    }
+
+    static Path growLock(Path poolDir) {
+        return poolDir.resolve(GROW_LOCK);
+    }
+
+    static Integer slotIndex(String dirName) {
+        if (!dirName.startsWith(SLOT_PREFIX)) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(dirName.substring(SLOT_PREFIX.length()));
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+}

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolProvisioner.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolProvisioner.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Provisions a single slot: clone the source install, patch the per-slot
+ * ports into {@code domain.xml}, run {@code asadmin start-domain}, then
+ * publish a {@code ports.properties} so the test JVM can pick up the slot.
+ *
+ * <p>Idempotent: a slot whose admin port already responds is left alone.
+ * Lets {@link PoolBootstrap#up} be re-run safely after a partial failure.
+ */
+public final class PoolProvisioner {
+
+    private static final Logger LOG = Logger.getLogger(PoolProvisioner.class.getName());
+
+    /** Subdirectory under each slot dir holding the cloned GlassFish install. */
+    public static final String SLOT_INSTALL_DIRNAME = "glassfish";
+
+    private static final int HEALTH_PROBE_TIMEOUT_MILLIS = 1000;
+
+    private final PoolConfig config;
+
+    public PoolProvisioner(PoolConfig config) {
+        this.config = config;
+    }
+
+    /**
+     * Provision slot {@code idx}. Returns the slot's published
+     * {@link SlotPorts} on success.
+     */
+    public SlotPorts provisionSlot(int idx) throws IOException {
+        if (config.source() == null) {
+            throw new IllegalStateException(
+                    "PoolConfig.source is null — set " + PoolConfig.SYS_SOURCE
+                    + " or pass it to the Maven plugin");
+        }
+        int adminPort = config.adminPort(idx);
+        int httpPort = config.httpPort(idx);
+        int httpsPort = config.httpsPort(idx);
+
+        Path slotDir = PoolPaths.slotDir(config.poolDir(), idx);
+        Path slotInstall = slotDir.resolve(SLOT_INSTALL_DIRNAME);
+        Path portsFile = PoolPaths.portsFile(config.poolDir(), idx);
+
+        // Idempotency: skip the heavy work if the slot is already alive and the
+        // ports file is consistent.
+        if (Files.exists(portsFile) && isPortHealthy(adminPort)) {
+            LOG.fine(() -> "Slot " + idx + " already healthy on adminPort=" + adminPort);
+            return SlotPorts.readFrom(portsFile);
+        }
+
+        Files.createDirectories(slotDir);
+
+        // tryGrow may have pre-created an empty slot dir to claim the index;
+        // wipe its contents (but not the dir itself) so a concurrent caller's
+        // Files.exists check still sees the claim while we re-clone.
+        if (Files.isDirectory(slotInstall)) {
+            deleteRecursive(slotInstall);
+        }
+
+        LOG.info("Cloning source install for slot " + idx + " (adminPort=" + adminPort + ")");
+        PoolSourceCloner.clone(config.source(), slotInstall);
+
+        Path domainXml = slotInstall
+                .resolve("glassfish").resolve("domains").resolve("domain1")
+                .resolve("config").resolve("domain.xml");
+        DomainXmlEditor.setPorts(domainXml, adminPort, httpPort, httpsPort);
+
+        AsAdmin asadmin = new AsAdmin(slotInstall);
+        try {
+            asadmin.run("start-domain", "domain1");
+        } catch (AsAdmin.AsAdminException e) {
+            LOG.log(Level.SEVERE, "Slot " + idx + " start-domain failed", e);
+            throw new IOException("Slot " + idx + " start-domain failed: " + e.getMessage(), e);
+        }
+
+        SlotPorts ports = new SlotPorts(adminPort, httpPort, httpsPort, slotInstall.toString());
+        ports.writeTo(portsFile);
+        LOG.info("Slot " + idx + " provisioned: adminPort=" + adminPort + ", http=" + httpPort);
+        return ports;
+    }
+
+    /** Stop a slot's GlassFish if its admin port is responding. Best-effort; logs failures. */
+    public void stopSlot(int idx) {
+        Path slotInstall = PoolPaths.slotDir(config.poolDir(), idx).resolve(SLOT_INSTALL_DIRNAME);
+        if (!Files.isDirectory(slotInstall)) {
+            return;
+        }
+        try {
+            new AsAdmin(slotInstall).run("stop-domain", "domain1");
+            LOG.info("Slot " + idx + " stopped");
+        } catch (AsAdmin.AsAdminException e) {
+            LOG.log(Level.WARNING, "Slot " + idx + " stop-domain failed: " + e.getMessage());
+        }
+    }
+
+    /** TCP probe — same heuristic SlotLeaser uses to decide a slot is alive. */
+    static boolean isPortHealthy(int port) {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress("localhost", port), HEALTH_PROBE_TIMEOUT_MILLIS);
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private static void deleteRecursive(Path root) throws IOException {
+        if (!Files.exists(root)) {
+            return;
+        }
+        try (var entries = Files.walk(root)) {
+            entries.sorted(Comparator.reverseOrder()).forEach(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (IOException ignored) {
+                    // Best-effort; provisioning will overwrite what it needs.
+                }
+            });
+        }
+    }
+}

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolSourceCloner.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolSourceCloner.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.logging.Logger;
+
+/**
+ * Clones a source GlassFish install tree into a slot directory using
+ * {@link Files#createLink hardlinks} so N slots cost ~one source's worth
+ * of disk space — the {@code cp -al} idiom in pure Java.
+ *
+ * <p>{@link Files#createLink} is supported on Linux, macOS (HFS+/APFS) and
+ * Windows (NTFS). When it isn't (cross-filesystem boundary, FAT, etc.) we
+ * fall back to a regular copy so the clone still succeeds; the slot just
+ * costs full disk.
+ *
+ * <p>Hardlinks are safe for the GlassFish tree only because the provisioner
+ * uses inode-replacing writes via {@link DomainXmlEditor#setPorts} when it
+ * patches the slot's {@code domain.xml}. A naive in-place truncate would
+ * also rewrite the source's {@code domain.xml} through its hardlinked twin.
+ */
+final class PoolSourceCloner {
+
+    private static final Logger LOG = Logger.getLogger(PoolSourceCloner.class.getName());
+
+    private PoolSourceCloner() {
+    }
+
+    static void clone(Path source, Path target) throws IOException {
+        if (!Files.isDirectory(source)) {
+            throw new IllegalArgumentException("Source is not a directory: " + source);
+        }
+        Files.createDirectories(target);
+        Files.walkFileTree(source, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                Path rel = source.relativize(dir);
+                Path dest = target.resolve(rel.toString());
+                Files.createDirectories(dest);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Path rel = source.relativize(file);
+                Path dest = target.resolve(rel.toString());
+                if (Files.exists(dest)) {
+                    return FileVisitResult.CONTINUE;
+                }
+                try {
+                    Files.createLink(dest, file);
+                } catch (UnsupportedOperationException | IOException e) {
+                    // Cross-filesystem, FAT, or hardlinks disabled — fall back to copy.
+                    // (We log once per slot at most; chatter would dominate the build log.)
+                    LOG.fine(() -> "Hardlink failed (" + e.getMessage() + "), copying " + rel);
+                    Files.copy(file, dest, StandardCopyOption.COPY_ATTRIBUTES);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+}

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolStaging.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolStaging.java
@@ -94,6 +94,10 @@ public final class PoolStaging {
         Path target = spec.overlayTargetDir();
         Files.createDirectories(target);
         for (OverlayCoord overlay : spec.overlays()) {
+            if (overlay.isSkip()) {
+                LOG.info("Skipping overlay " + overlay.toGav() + " (skip=true)");
+                continue;
+            }
             Path source = resolver.resolve(overlay);
             String fileName = (overlay.getDestFileName() == null || overlay.getDestFileName().isEmpty())
                     ? source.getFileName().toString()

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolStaging.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolStaging.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.EnumSet;
+import java.util.Properties;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
+
+/**
+ * Optional pre-step for {@link PoolBootstrap#up}: resolve and unpack the
+ * GlassFish distribution zip, then copy overlay artifacts into the staged
+ * install.
+ *
+ * <p>Pure Java: artifact lookup is delegated to a caller-supplied
+ * {@link ArtifactResolver} so the {@code glassfish-pool} module does not
+ * depend on Aether. The Maven plugin module wires Aether in.
+ *
+ * <p>Concurrency: callers are expected to invoke {@link #stage} from inside
+ * {@link PoolBootstrap}'s {@code UP_LOCK} synchronized block. The marker
+ * check makes a second concurrent run a no-op even without that, but the
+ * unpack itself is not safe to interleave.
+ */
+public final class PoolStaging {
+
+    private static final Logger LOG = Logger.getLogger(PoolStaging.class.getName());
+
+    private static final String MARKER_FILE = ".staging-glassfish.properties";
+    private static final String MARKER_KEY_DIST = "distribution";
+
+    /** Resolves a GAV to a local file (typically the artifact under {@code ~/.m2/repository}). */
+    @FunctionalInterface
+    public interface ArtifactResolver {
+        Path resolve(ArtifactCoord coord) throws IOException;
+    }
+
+    private PoolStaging() {
+    }
+
+    /**
+     * Run the staging steps. Either side is a no-op when its skip flag is set
+     * or its inputs are empty. The unpack step is marker-guarded: it skips
+     * when the staged install already records the requested dist GAV, and
+     * wipes + re-unpacks when the GAV differs. Overlays are always re-copied
+     * (cheap; lets {@code -Dmojarra.version=…} take effect without a wipe).
+     */
+    public static void stage(StageSpec spec, ArtifactResolver resolver) throws IOException {
+        if (!spec.unpackSkip() && spec.distribution() != null) {
+            unpackDistribution(spec, resolver);
+        }
+        if (!spec.overlaySkip() && !spec.overlays().isEmpty()) {
+            copyOverlays(spec, resolver);
+        }
+    }
+
+    private static void unpackDistribution(StageSpec spec, ArtifactResolver resolver) throws IOException {
+        Path stageDir = spec.stageDir();
+        Path marker = stageDir.resolve(MARKER_FILE);
+        String wantedGav = spec.distribution().toGav();
+        if (Files.exists(marker)) {
+            String stagedGav = readMarker(marker, MARKER_KEY_DIST);
+            if (wantedGav.equals(stagedGav)) {
+                LOG.fine("Dist already staged at " + stageDir + " (" + wantedGav + ")");
+                return;
+            }
+            LOG.info("Re-staging dist (was " + stagedGav + ", now " + wantedGav + ")");
+            wipe(stageDir);
+        }
+        Path zip = resolver.resolve(spec.distribution());
+        Files.createDirectories(stageDir);
+        LOG.info("Unpacking " + wantedGav + " to " + stageDir);
+        unzip(zip, stageDir);
+        writeMarker(marker, MARKER_KEY_DIST, wantedGav);
+    }
+
+    private static void copyOverlays(StageSpec spec, ArtifactResolver resolver) throws IOException {
+        Path target = spec.overlayTargetDir();
+        Files.createDirectories(target);
+        for (OverlayCoord overlay : spec.overlays()) {
+            Path source = resolver.resolve(overlay);
+            String fileName = (overlay.getDestFileName() == null || overlay.getDestFileName().isEmpty())
+                    ? source.getFileName().toString()
+                    : overlay.getDestFileName();
+            Path dest = target.resolve(fileName);
+            Files.copy(source, dest, StandardCopyOption.REPLACE_EXISTING);
+            LOG.info("Overlaid " + overlay.toGav() + " → " + dest);
+        }
+    }
+
+    /**
+     * Unzip preserving POSIX permissions. Uses commons-compress because
+     * {@link java.util.zip.ZipFile} doesn't expose external file attributes,
+     * which {@code asadmin}'s {@code +x} bit lives in.
+     */
+    private static void unzip(Path zip, Path targetDir) throws IOException {
+        try (ZipFile zf = ZipFile.builder().setFile(zip.toFile()).get()) {
+            var entries = zf.getEntries();
+            while (entries.hasMoreElements()) {
+                ZipArchiveEntry entry = entries.nextElement();
+                Path resolved = targetDir.resolve(entry.getName()).normalize();
+                if (!resolved.startsWith(targetDir)) {
+                    throw new IOException("Zip entry escapes target dir: " + entry.getName());
+                }
+                if (entry.isDirectory()) {
+                    Files.createDirectories(resolved);
+                    continue;
+                }
+                Files.createDirectories(resolved.getParent());
+                try (InputStream in = zf.getInputStream(entry)) {
+                    Files.copy(in, resolved, StandardCopyOption.REPLACE_EXISTING);
+                }
+                applyUnixMode(resolved, entry.getUnixMode());
+            }
+        }
+    }
+
+    private static void applyUnixMode(Path file, int unixMode) {
+        if (unixMode == 0) {
+            return;
+        }
+        Set<PosixFilePermission> perms = EnumSet.noneOf(PosixFilePermission.class);
+        if ((unixMode & 0400) != 0) perms.add(PosixFilePermission.OWNER_READ);
+        if ((unixMode & 0200) != 0) perms.add(PosixFilePermission.OWNER_WRITE);
+        if ((unixMode & 0100) != 0) perms.add(PosixFilePermission.OWNER_EXECUTE);
+        if ((unixMode & 0040) != 0) perms.add(PosixFilePermission.GROUP_READ);
+        if ((unixMode & 0020) != 0) perms.add(PosixFilePermission.GROUP_WRITE);
+        if ((unixMode & 0010) != 0) perms.add(PosixFilePermission.GROUP_EXECUTE);
+        if ((unixMode & 0004) != 0) perms.add(PosixFilePermission.OTHERS_READ);
+        if ((unixMode & 0002) != 0) perms.add(PosixFilePermission.OTHERS_WRITE);
+        if ((unixMode & 0001) != 0) perms.add(PosixFilePermission.OTHERS_EXECUTE);
+        try {
+            Files.setPosixFilePermissions(file, perms);
+        } catch (UnsupportedOperationException | IOException ignored) {
+            // Non-POSIX filesystem (Windows). Skip silently — Windows doesn't need +x.
+        }
+    }
+
+    private static void wipe(Path dir) throws IOException {
+        if (!Files.exists(dir)) {
+            return;
+        }
+        try (var entries = Files.walk(dir)) {
+            entries.sorted(java.util.Comparator.reverseOrder()).forEach(p -> {
+                try {
+                    Files.deleteIfExists(p);
+                } catch (IOException ignored) {
+                    /* best-effort */
+                }
+            });
+        }
+    }
+
+    private static String readMarker(Path marker, String key) {
+        Properties props = new Properties();
+        try (InputStream in = Files.newInputStream(marker)) {
+            props.load(in);
+        } catch (IOException e) {
+            return null;
+        }
+        return props.getProperty(key);
+    }
+
+    private static void writeMarker(Path marker, String key, String value) throws IOException {
+        Properties props = new Properties();
+        if (Files.exists(marker)) {
+            try (InputStream in = Files.newInputStream(marker)) {
+                props.load(in);
+            }
+        }
+        props.setProperty(key, value);
+        Files.createDirectories(marker.getParent());
+        try (var out = Files.newOutputStream(marker)) {
+            props.store(out, "glassfish-pool staging marker");
+        }
+    }
+}

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/SlotLease.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/SlotLease.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+
+/**
+ * Active hold on one slot. Closed when the test JVM is done with the slot;
+ * also closed automatically at JVM exit (via the lock file's {@link FileChannel}
+ * being released).
+ */
+public final class SlotLease implements AutoCloseable {
+
+    private final int slotIndex;
+    private final SlotPorts ports;
+    private final FileChannel channel;
+    private final FileLock lock;
+    private volatile boolean released;
+
+    SlotLease(int slotIndex, SlotPorts ports, FileChannel channel, FileLock lock) {
+        this.slotIndex = slotIndex;
+        this.ports = ports;
+        this.channel = channel;
+        this.lock = lock;
+    }
+
+    public int slotIndex() {
+        return slotIndex;
+    }
+
+    public SlotPorts ports() {
+        return ports;
+    }
+
+    @Override
+    public synchronized void close() {
+        if (released) {
+            return;
+        }
+        released = true;
+        try {
+            lock.release();
+        } catch (IOException ignored) {
+            // Lock already released or channel closed — same end state.
+        }
+        try {
+            channel.close();
+        } catch (IOException ignored) {
+            // FD released either way.
+        }
+    }
+}

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/SlotLeaser.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/SlotLeaser.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * Pure-Java port of the file-lock-based slot lease protocol from the Faces
+ * TCK's {@code SlotLeaserAgent}. Used by the Arquillian extension at test-JVM
+ * startup to acquire one of the pre-started slots, and by tools/tests for
+ * the same purpose.
+ *
+ * <p>Protocol per slot:
+ * <ul>
+ *   <li>{@code slot-N/lock} — one byte per JVM, exclusively locked via
+ *       {@link FileChannel#tryLock()}. Linux/macOS use {@code fcntl} locks
+ *       under the hood; on Windows the locking is mandatory.</li>
+ *   <li>{@code slot-N/ports.properties} — appears once provisioning completes.
+ *       A slot dir without it is mid-bootstrap and skipped by the scan.</li>
+ * </ul>
+ *
+ * <p>If every existing slot is busy the leaser tries to grow the pool: it
+ * acquires {@code grow.lock}, picks the next index (preferring to recycle a
+ * dead slot), releases the lock, and runs the provisioner. The provisioning
+ * itself is OUTSIDE {@code grow.lock} so concurrent test JVMs that all need
+ * a cold slot grow in parallel rather than serialising.
+ */
+public final class SlotLeaser {
+
+    private static final Logger LOG = Logger.getLogger(SlotLeaser.class.getName());
+
+    private static final long DEFAULT_TIMEOUT_SECONDS = 600L;
+    private static final long POLL_INTERVAL_MILLIS = 500L;
+
+    private final PoolConfig config;
+    private final long timeoutSeconds;
+
+    public SlotLeaser(PoolConfig config) {
+        this(config, DEFAULT_TIMEOUT_SECONDS);
+    }
+
+    public SlotLeaser(PoolConfig config, long timeoutSeconds) {
+        this.config = config;
+        this.timeoutSeconds = timeoutSeconds;
+    }
+
+    /**
+     * Lease a slot, growing the pool if necessary. Blocks up to the configured
+     * timeout. Throws if no slot can be obtained in time.
+     */
+    public SlotLease lease() throws IOException, InterruptedException {
+        Path poolDir = config.poolDir();
+        if (!Files.isDirectory(poolDir)) {
+            throw new IllegalStateException(
+                    "Pool dir does not exist: " + poolDir
+                    + " — has the pool been provisioned (e.g. via PoolBootstrap.up)?");
+        }
+        long deadline = System.currentTimeMillis() + (timeoutSeconds * 1000L);
+
+        while (System.currentTimeMillis() < deadline) {
+            SlotLease leased = scanAndTryAcquire(poolDir);
+            if (leased != null) {
+                return leased;
+            }
+            int grown = tryGrow(poolDir);
+            if (grown > 0) {
+                SlotLease grownLease = tryAcquire(poolDir, grown);
+                if (grownLease != null) {
+                    return grownLease;
+                }
+            }
+            Thread.sleep(POLL_INTERVAL_MILLIS);
+        }
+        throw new IllegalStateException(
+                "Could not lease a GlassFish pool slot within " + timeoutSeconds + "s (pool=" + poolDir + ")");
+    }
+
+    /**
+     * One scan pass: enumerate ready slots (those with {@code ports.properties})
+     * and try to lock each in least-recently-leased order. Returns the first
+     * successful lease, or {@code null} if every ready slot is busy.
+     *
+     * <p>Sorting by lock-file mtime biases toward the slot that's been idle
+     * the longest, which evens out load when tests have wildly different
+     * durations.
+     */
+    private SlotLease scanAndTryAcquire(Path poolDir) throws IOException {
+        List<Integer> candidates = new ArrayList<>();
+        try (var entries = Files.list(poolDir)) {
+            for (Path entry : (Iterable<Path>) entries::iterator) {
+                Integer idx = PoolPaths.slotIndex(entry.getFileName().toString());
+                if (idx == null) {
+                    continue;
+                }
+                if (!Files.exists(PoolPaths.portsFile(poolDir, idx))) {
+                    continue;
+                }
+                candidates.add(idx);
+            }
+        }
+        candidates.sort(Comparator.comparingLong(slot -> lockMtime(poolDir, slot)));
+        for (int slot : candidates) {
+            SlotLease leased = tryAcquire(poolDir, slot);
+            if (leased != null) {
+                return leased;
+            }
+        }
+        return null;
+    }
+
+    private SlotLease tryAcquire(Path poolDir, int slot) throws IOException {
+        Path portsFile = PoolPaths.portsFile(poolDir, slot);
+        if (!Files.exists(portsFile)) {
+            return null;
+        }
+        FileChannel channel = FileChannel.open(PoolPaths.lockFile(poolDir, slot),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.READ,
+                StandardOpenOption.WRITE);
+        FileLock lock = null;
+        try {
+            lock = channel.tryLock();
+            if (lock == null) {
+                channel.close();
+                return null;
+            }
+            SlotPorts ports;
+            try {
+                ports = SlotPorts.readFrom(portsFile);
+            } catch (IOException | RuntimeException e) {
+                // Half-written ports.properties — skip the slot, scan continues.
+                lock.release();
+                channel.close();
+                return null;
+            }
+            // A free lock file does not imply a live GF: previous owner's GF may
+            // have OOM-crashed, been killed, or been mid-shutdown when we grabbed
+            // the lock. Probe before committing.
+            if (!PoolProvisioner.isPortHealthy(ports.adminPort())) {
+                lock.release();
+                channel.close();
+                return null;
+            }
+            // Expose the slot index as a system property so test-side
+            // observers (logging filters, progress listeners, etc.) can tag
+            // their output with the slot number. Set even on a single-slot
+            // pool so consumers can rely on the property existing.
+            System.setProperty("gf.pool.slot", String.valueOf(slot));
+            LOG.fine(() -> "Leased slot " + slot + " (adminPort=" + ports.adminPort() + ")");
+            return new SlotLease(slot, ports, channel, lock);
+        } catch (RuntimeException | IOException e) {
+            // Always release the channel between open() and successful return,
+            // otherwise a transient failure leaks an FD per poll cycle.
+            if (lock != null) {
+                try {
+                    lock.release();
+                } catch (IOException ignored) {
+                    /* nothing useful */
+                }
+            }
+            try {
+                channel.close();
+            } catch (IOException ignored) {
+                /* nothing useful */
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Pick the next free slot index under {@code grow.lock}, then provision it
+     * outside the lock. Returns the chosen index on successful provisioning,
+     * or 0 if no provisioning happened (no source configured, someone else
+     * won the race, or provisioning failed).
+     */
+    private int tryGrow(Path poolDir) throws IOException {
+        if (config.source() == null) {
+            // Caller didn't supply a source install — typical for test-JVM
+            // leasers when the build hasn't forwarded gf.pool.source. Skip
+            // grow so the lease loop just waits for an existing slot.
+            return 0;
+        }
+        Path growLock = PoolPaths.growLock(poolDir);
+        int chosen;
+        try (FileChannel fc = FileChannel.open(growLock,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.READ,
+                StandardOpenOption.WRITE);
+             FileLock ignored = fc.lock()) {
+            int recycle = findRecyclableSlot(poolDir);
+            if (recycle > 0) {
+                chosen = recycle;
+                // Caller will overwrite contents; we keep the dir to keep the claim visible.
+            } else {
+                chosen = 1;
+                while (Files.exists(PoolPaths.slotDir(poolDir, chosen))) {
+                    chosen++;
+                }
+                Files.createDirectory(PoolPaths.slotDir(poolDir, chosen));
+            }
+        }
+        final int chosenFinal = chosen;
+        try {
+            new PoolProvisioner(config).provisionSlot(chosenFinal);
+        } catch (IOException e) {
+            LOG.warning(() -> "Slot " + chosenFinal + " provisioning failed during grow: " + e.getMessage());
+            return 0;
+        }
+        return chosenFinal;
+    }
+
+    /**
+     * Lowest slot index whose GF JVM is dead (admin port closed) AND whose
+     * lock file is currently free. Recycling avoids the pool exceeding the
+     * concurrency cap implied by {@code -T} after a slot dies.
+     */
+    private int findRecyclableSlot(Path poolDir) throws IOException {
+        List<Integer> indices = new ArrayList<>();
+        try (var entries = Files.list(poolDir)) {
+            for (Path entry : (Iterable<Path>) entries::iterator) {
+                Integer idx = PoolPaths.slotIndex(entry.getFileName().toString());
+                if (idx == null) {
+                    continue;
+                }
+                if (!Files.exists(PoolPaths.portsFile(poolDir, idx))) {
+                    continue; // mid-bootstrap; not ours to recycle
+                }
+                indices.add(idx);
+            }
+        }
+        indices.sort(Comparator.naturalOrder());
+        for (int slot : indices) {
+            SlotPorts ports;
+            try {
+                ports = SlotPorts.readFrom(PoolPaths.portsFile(poolDir, slot));
+            } catch (IOException | RuntimeException e) {
+                continue;
+            }
+            if (PoolProvisioner.isPortHealthy(ports.adminPort())) {
+                continue;
+            }
+            try (FileChannel ch = FileChannel.open(PoolPaths.lockFile(poolDir, slot),
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.READ,
+                    StandardOpenOption.WRITE)) {
+                FileLock probe = ch.tryLock();
+                if (probe == null) {
+                    continue;
+                }
+                probe.release();
+                return slot;
+            } catch (IOException e) {
+                /* skip */
+            }
+        }
+        return 0;
+    }
+
+    private static long lockMtime(Path poolDir, int slot) {
+        try {
+            return Files.getLastModifiedTime(PoolPaths.lockFile(poolDir, slot)).toMillis();
+        } catch (IOException e) {
+            return 0L;
+        }
+    }
+}

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/SlotPorts.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/SlotPorts.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+
+/**
+ * Per-slot {@code ports.properties}: produced by the provisioner once a slot's
+ * GlassFish is up, consumed by the test JVM at lease time.
+ *
+ * <p>Property names are deliberately the same as the keys
+ * {@link ee.omnifish.arquillian.container.glassfish.CommonGlassFishConfiguration}
+ * expects so a leased slot's properties can be applied to a container config
+ * verbatim.
+ */
+public final class SlotPorts {
+
+    public static final String ADMIN_PORT = "glassfish.adminPort";
+    public static final String HTTP_PORT = "glassfish.httpPort";
+    public static final String HTTPS_PORT = "glassfish.httpsPort";
+    public static final String GLASSFISH_HOME = "glassfish.home";
+
+    private final int adminPort;
+    private final int httpPort;
+    private final int httpsPort;
+    private final String glassFishHome;
+
+    public SlotPorts(int adminPort, int httpPort, int httpsPort, String glassFishHome) {
+        this.adminPort = adminPort;
+        this.httpPort = httpPort;
+        this.httpsPort = httpsPort;
+        this.glassFishHome = glassFishHome;
+    }
+
+    public int adminPort() {
+        return adminPort;
+    }
+
+    public int httpPort() {
+        return httpPort;
+    }
+
+    public int httpsPort() {
+        return httpsPort;
+    }
+
+    public String glassFishHome() {
+        return glassFishHome;
+    }
+
+    public void writeTo(Path file) throws IOException {
+        Properties props = new Properties();
+        props.setProperty(ADMIN_PORT, String.valueOf(adminPort));
+        props.setProperty(HTTP_PORT, String.valueOf(httpPort));
+        props.setProperty(HTTPS_PORT, String.valueOf(httpsPort));
+        props.setProperty(GLASSFISH_HOME, glassFishHome);
+        // Atomic publish: write to sibling tmp + move. A test JVM scanning
+        // mid-write would otherwise see a half-formed properties file and
+        // skip the slot until the next poll.
+        Path tmp = file.resolveSibling(file.getFileName() + ".tmp");
+        try (OutputStream out = Files.newOutputStream(tmp)) {
+            props.store(out, "Slot ports — written by PoolProvisioner");
+        }
+        Files.move(tmp, file,
+                java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+                java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    public static SlotPorts readFrom(Path file) throws IOException {
+        Properties props = new Properties();
+        try (InputStream in = Files.newInputStream(file)) {
+            props.load(in);
+        }
+        return new SlotPorts(
+                requireInt(props, ADMIN_PORT),
+                requireInt(props, HTTP_PORT),
+                requireInt(props, HTTPS_PORT),
+                require(props, GLASSFISH_HOME));
+    }
+
+    private static String require(Properties p, String key) {
+        String v = p.getProperty(key);
+        if (v == null || v.isEmpty()) {
+            throw new IllegalStateException("Missing required property '" + key + "'");
+        }
+        return v;
+    }
+
+    private static int requireInt(Properties p, String key) {
+        try {
+            return Integer.parseInt(require(p, key));
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException("Property '" + key + "' is not numeric: " + p.getProperty(key));
+        }
+    }
+}

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/StageSpec.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/StageSpec.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Aggregates the optional staging step for {@link PoolBootstrap#up}: where to
+ * unpack the GlassFish dist, which dist artifact to fetch, and which overlay
+ * jars to drop into the staged install's {@code modules/}. Unpack and overlay
+ * each have their own skip flag so callers can opt out of one without the other
+ * (e.g. reuse an existing install but still overlay a custom Mojarra into it).
+ */
+public final class StageSpec {
+
+    private final Path stageDir;
+    private final ArtifactCoord distribution;
+    private final boolean unpackSkip;
+    private final Path overlayTargetDir;
+    private final List<OverlayCoord> overlays;
+    private final boolean overlaySkip;
+
+    public StageSpec(Path stageDir,
+                     ArtifactCoord distribution,
+                     boolean unpackSkip,
+                     Path overlayTargetDir,
+                     List<OverlayCoord> overlays,
+                     boolean overlaySkip) {
+        this.stageDir = stageDir;
+        this.distribution = distribution;
+        this.unpackSkip = unpackSkip;
+        this.overlayTargetDir = overlayTargetDir;
+        this.overlays = (overlays == null) ? List.of() : Collections.unmodifiableList(overlays);
+        this.overlaySkip = overlaySkip;
+    }
+
+    public Path stageDir() {
+        return stageDir;
+    }
+
+    public ArtifactCoord distribution() {
+        return distribution;
+    }
+
+    public boolean unpackSkip() {
+        return unpackSkip;
+    }
+
+    public Path overlayTargetDir() {
+        return overlayTargetDir;
+    }
+
+    public List<OverlayCoord> overlays() {
+        return overlays;
+    }
+
+    public boolean overlaySkip() {
+        return overlaySkip;
+    }
+
+    /** True iff at least one of unpack or overlay would do real work. */
+    public boolean hasWork() {
+        boolean willUnpack = !unpackSkip && distribution != null;
+        boolean willOverlay = !overlaySkip && !overlays.isEmpty();
+        return willUnpack || willOverlay;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof StageSpec)) {
+            return false;
+        }
+        StageSpec other = (StageSpec) o;
+        return unpackSkip == other.unpackSkip
+                && overlaySkip == other.overlaySkip
+                && Objects.equals(stageDir, other.stageDir)
+                && Objects.equals(distribution, other.distribution)
+                && Objects.equals(overlayTargetDir, other.overlayTargetDir)
+                && Objects.equals(overlays, other.overlays);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(stageDir, distribution, unpackSkip, overlayTargetDir, overlays, overlaySkip);
+    }
+}

--- a/glassfish-pool/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/glassfish-pool/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+ee.omnifish.arquillian.container.glassfish.pool.GlassFishPoolExtension

--- a/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/DomainXmlEditorTest.java
+++ b/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/DomainXmlEditorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DomainXmlEditorTest {
+
+    private static final String FRAGMENT =
+            "<network-listeners>"
+            + "<network-listener address=\"0.0.0.0\" port=\"4848\" protocol=\"admin-listener\" "
+            + "transport=\"tcp\" name=\"admin-listener\" thread-pool=\"admin-thread-pool\"></network-listener>"
+            + "<network-listener address=\"0.0.0.0\" port=\"8080\" protocol=\"http-listener-1\" "
+            + "transport=\"tcp\" name=\"http-listener-1\" thread-pool=\"http-thread-pool\"></network-listener>"
+            + "<network-listener address=\"0.0.0.0\" port=\"8181\" protocol=\"http-listener-2\" "
+            + "transport=\"tcp\" name=\"http-listener-2\" thread-pool=\"http-thread-pool\"></network-listener>"
+            + "</network-listeners>";
+
+    @Test
+    void rewritesAllThreePorts(@TempDir Path tmp) throws IOException {
+        Path domainXml = tmp.resolve("domain.xml");
+        Files.writeString(domainXml, FRAGMENT);
+
+        DomainXmlEditor.setPorts(domainXml, 14948, 14949, 14950);
+
+        String content = Files.readString(domainXml);
+        assertThat(content, containsString("port=\"14948\""));
+        assertThat(content, containsString("port=\"14949\""));
+        assertThat(content, containsString("port=\"14950\""));
+        assertThat(content, not(containsString("port=\"4848\"")));
+        assertThat(content, not(containsString("port=\"8080\"")));
+        assertThat(content, not(containsString("port=\"8181\"")));
+    }
+
+    @Test
+    void leavesPropertyPlaceholdersAlone(@TempDir Path tmp) throws IOException {
+        Path domainXml = tmp.resolve("domain.xml");
+        String withPlaceholder = FRAGMENT.replace("port=\"4848\"", "port=\"${ADMIN_PORT}\"");
+        Files.writeString(domainXml, withPlaceholder);
+
+        DomainXmlEditor.setPorts(domainXml, 14948, 14949, 14950);
+
+        String content = Files.readString(domainXml);
+        assertThat(content, containsString("port=\"${ADMIN_PORT}\""));
+        assertThat(content, containsString("port=\"14949\""));
+    }
+
+    @Test
+    void atomicWriteReplacesInodeNotTruncatesIt(@TempDir Path tmp) throws IOException {
+        // Simulate hardlinked source: a second name pointing at the same inode.
+        // After setPorts, the source inode (and its other names) should NOT see
+        // the new content — that's the contract that protects the source install.
+        Path source = tmp.resolve("source.xml");
+        Path slot = tmp.resolve("slot.xml");
+        Files.writeString(source, FRAGMENT);
+        try {
+            Files.createLink(slot, source);
+        } catch (UnsupportedOperationException | IOException e) {
+            // Filesystem doesn't support hardlinks (e.g. /tmp on tmpfs sometimes);
+            // skip the inode-isolation assertion entirely.
+            return;
+        }
+
+        DomainXmlEditor.setPorts(slot, 14948, 14949, 14950);
+
+        String slotContent = Files.readString(slot);
+        String sourceContent = Files.readString(source);
+        assertThat(slotContent, containsString("port=\"14948\""));
+        assertThat(sourceContent, containsString("port=\"4848\""));
+        assertThat(sourceContent.equals(slotContent), is(false));
+    }
+}

--- a/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/PoolBootstrapTest.java
+++ b/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/PoolBootstrapTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PoolBootstrapTest {
+
+    private final List<ServerSocket> fakes = new ArrayList<>();
+
+    @AfterEach
+    void closeFakes() throws IOException {
+        for (ServerSocket s : fakes) {
+            s.close();
+        }
+        fakes.clear();
+    }
+
+    /**
+     * If every slot already has a healthy admin port, {@code up} must fast-exit
+     * without touching the source install. The test exercises this by pre-seeding
+     * slot-1 with a fake "alive" admin port (loopback {@link ServerSocket}) and
+     * passing {@code source=null} — if {@code up} tried to provision, it would
+     * fail with NPE/IllegalStateException on the missing source.
+     */
+    @Test
+    void upFastExitsWhenPoolHealthy(@TempDir Path tmp) throws Exception {
+        int adminPort = openFake();
+        Files.createDirectories(PoolPaths.slotDir(tmp, 1));
+        new SlotPorts(adminPort, adminPort + 1, adminPort + 2, "/fake")
+                .writeTo(PoolPaths.portsFile(tmp, 1));
+
+        PoolConfig config = new PoolConfig(tmp, /*source*/null, 1,
+                PoolConfig.DEFAULT_ADMIN_BASE, PoolConfig.DEFAULT_PORT_STRIDE);
+        PoolBootstrap.up(config); // would throw if it tried to provision
+    }
+
+    /**
+     * Two threads call {@code up} concurrently. Both should return cleanly
+     * without exceptions; the {@code synchronized} block plus the fast-exit
+     * means only the first one (if any) does work. With a pre-seeded healthy
+     * pool, neither does work — but the synchronized block is still exercised.
+     */
+    @Test
+    void concurrentUpsAreSerialised(@TempDir Path tmp) throws Exception {
+        int adminPort = openFake();
+        Files.createDirectories(PoolPaths.slotDir(tmp, 1));
+        new SlotPorts(adminPort, adminPort + 1, adminPort + 2, "/fake")
+                .writeTo(PoolPaths.portsFile(tmp, 1));
+
+        PoolConfig config = new PoolConfig(tmp, null, 1,
+                PoolConfig.DEFAULT_ADMIN_BASE, PoolConfig.DEFAULT_PORT_STRIDE);
+
+        ExecutorService exec = Executors.newFixedThreadPool(4);
+        try {
+            List<CompletableFuture<Void>> tasks = new ArrayList<>();
+            for (int i = 0; i < 4; i++) {
+                tasks.add(CompletableFuture.runAsync(() -> {
+                    try {
+                        PoolBootstrap.up(config);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }, exec));
+            }
+            CompletableFuture.allOf(tasks.toArray(new CompletableFuture[0]))
+                    .get(10, TimeUnit.SECONDS);
+        } finally {
+            exec.shutdown();
+        }
+    }
+
+    @Test
+    void downIsNoopOnEmptyPool(@TempDir Path tmp) {
+        PoolConfig config = new PoolConfig(tmp, null, 0,
+                PoolConfig.DEFAULT_ADMIN_BASE, PoolConfig.DEFAULT_PORT_STRIDE);
+        PoolBootstrap.down(config); // must not throw
+    }
+
+    @Test
+    void statusOnEmptyPoolDirPrintsHint(@TempDir Path tmp) {
+        Path missing = tmp.resolve("nope");
+        PoolConfig config = new PoolConfig(missing, null, 0,
+                PoolConfig.DEFAULT_ADMIN_BASE, PoolConfig.DEFAULT_PORT_STRIDE);
+        // Just verify no exception; output goes to stdout.
+        PoolBootstrap.status(config);
+        assertThat(Files.exists(missing), equalTo(false));
+    }
+
+    /**
+     * A slot directory with no {@code ports.properties} and no live process
+     * holding the slot lock represents an abandoned bootstrap (e.g. Maven was
+     * Ctrl+C'd mid-provisioning). Status must label it {@code orphan}, not
+     * {@code bootstrap}, so the operator knows to nuke vs. wait.
+     */
+    @Test
+    void statusLabelsAbandonedSlotAsOrphan(@TempDir Path tmp) throws Exception {
+        Files.createDirectories(PoolPaths.slotDir(tmp, 1));
+        PoolConfig config = new PoolConfig(tmp, null, 1,
+                PoolConfig.DEFAULT_ADMIN_BASE, PoolConfig.DEFAULT_PORT_STRIDE);
+
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        PrintStream original = System.out;
+        System.setOut(new PrintStream(buf, true, StandardCharsets.UTF_8));
+        try {
+            PoolBootstrap.status(config);
+        } finally {
+            System.setOut(original);
+        }
+        assertThat(buf.toString(StandardCharsets.UTF_8), containsString("orphan"));
+    }
+
+    private int openFake() throws IOException {
+        // Backlog 50 so a flurry of concurrent isPortHealthy probes (used in
+        // the parallel test) don't fall off the listen queue. backlog=1 makes
+        // even 4-thread fan-in flaky on Linux.
+        ServerSocket socket = new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
+        fakes.add(socket);
+        return socket.getLocalPort();
+    }
+}

--- a/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/PoolConfigTest.java
+++ b/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/PoolConfigTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+class PoolConfigTest {
+
+    @Test
+    void portStrideMath() {
+        PoolConfig config = new PoolConfig(
+                Paths.get("/tmp/pool"), Paths.get("/src"), 4, 14848, 100);
+        assertThat(config.adminPort(1), equalTo(14848));
+        assertThat(config.httpPort(1), equalTo(14849));
+        assertThat(config.httpsPort(1), equalTo(14850));
+        assertThat(config.adminPort(4), equalTo(15148));
+    }
+
+    @Test
+    void rejectsTooSmallStride() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new PoolConfig(Paths.get("/x"), null, 1, 14848, 5));
+    }
+
+    @Test
+    void acceptsMinStride() {
+        // 10 is the documented minimum (one GF domain occupies 10 ports).
+        PoolConfig c = new PoolConfig(Paths.get("/x"), null, 1, 14848, 10);
+        assertThat(c.portStride(), equalTo(10));
+    }
+}

--- a/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/PoolStagingTest.java
+++ b/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/PoolStagingTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PoolStagingTest {
+
+    @Test
+    void perOverlaySkipIsHonoured(@TempDir Path tmp) throws IOException {
+        Path stage = tmp.resolve("stage");
+        Path modules = tmp.resolve("modules");
+        Path repo = Files.createDirectories(tmp.resolve("repo"));
+
+        Path copiedJar = repo.resolve("copied.jar");
+        Path skippedJar = repo.resolve("skipped.jar");
+        Files.writeString(copiedJar, "copied");
+        Files.writeString(skippedJar, "skipped");
+
+        OverlayCoord copied = new OverlayCoord("g", "copied", "1", "jar", null, "copied.jar");
+        OverlayCoord skipped = new OverlayCoord("g", "skipped", "1", "jar", null, "skipped.jar");
+        skipped.setSkip(true);
+
+        StageSpec spec = new StageSpec(stage, null, true, modules,
+                List.of(copied, skipped), false);
+
+        PoolStaging.stage(spec, coord -> "copied".equals(coord.getArtifactId()) ? copiedJar : skippedJar);
+
+        assertThat(Files.exists(modules.resolve("copied.jar")), is(true));
+        assertThat(Files.exists(modules.resolve("skipped.jar")), is(false));
+        assertThat(Files.readString(modules.resolve("copied.jar")), equalTo("copied"));
+    }
+}

--- a/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/SlotLeaserTest.java
+++ b/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/SlotLeaserTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tests {@link SlotLeaser} against a tmp pool dir, using real
+ * {@link ServerSocket}s on loopback to play the role of "alive" admin ports.
+ * Fake sockets let us exercise the health probe path without spinning up a
+ * real GlassFish — much faster than the integration test, and runs in CI.
+ */
+class SlotLeaserTest {
+
+    private final List<ServerSocket> fakes = new ArrayList<>();
+
+    @AfterEach
+    void closeFakes() throws IOException {
+        for (ServerSocket s : fakes) {
+            s.close();
+        }
+        fakes.clear();
+    }
+
+    @Test
+    void leasesAReadySlot(@TempDir Path tmp) throws Exception {
+        int adminPort = openFake();
+        seedSlot(tmp, 1, adminPort);
+
+        try (SlotLease lease = leaserFor(tmp).lease()) {
+            assertThat(lease, notNullValue());
+            assertThat(lease.slotIndex(), equalTo(1));
+            assertThat(lease.ports().adminPort(), equalTo(adminPort));
+        }
+    }
+
+    @Test
+    void prefersLeastRecentlyUsedSlot(@TempDir Path tmp) throws Exception {
+        int port1 = openFake();
+        int port2 = openFake();
+        seedSlot(tmp, 1, port1);
+        seedSlot(tmp, 2, port2);
+
+        // Touch slot-2's lock with an older mtime so it sorts first.
+        Path lock1 = PoolPaths.lockFile(tmp, 1);
+        Path lock2 = PoolPaths.lockFile(tmp, 2);
+        Files.createFile(lock1);
+        Files.createFile(lock2);
+        Files.setLastModifiedTime(lock1, java.nio.file.attribute.FileTime.fromMillis(2000));
+        Files.setLastModifiedTime(lock2, java.nio.file.attribute.FileTime.fromMillis(1000));
+
+        try (SlotLease lease = leaserFor(tmp).lease()) {
+            assertThat(lease.slotIndex(), equalTo(2));
+        }
+    }
+
+    @Test
+    void skipsDeadSlotAndPicksAlive(@TempDir Path tmp) throws Exception {
+        int dead = freePort();      // closed before we try
+        int alive = openFake();
+        seedSlot(tmp, 1, dead);
+        seedSlot(tmp, 2, alive);
+
+        try (SlotLease lease = leaserFor(tmp).lease()) {
+            assertThat(lease.slotIndex(), equalTo(2));
+        }
+    }
+
+    @Test
+    void timesOutWhenNoLiveSlotExists(@TempDir Path tmp) throws Exception {
+        seedSlot(tmp, 1, freePort());
+
+        SlotLeaser leaser = new SlotLeaser(
+                new PoolConfig(tmp, null, 0, PoolConfig.DEFAULT_ADMIN_BASE, PoolConfig.DEFAULT_PORT_STRIDE),
+                1L);
+        assertThrows(IllegalStateException.class, leaser::lease);
+    }
+
+    @Test
+    void skipsSlotsWithoutPortsFile(@TempDir Path tmp) throws Exception {
+        // Mid-bootstrap dir: exists, no ports.properties — leaser should ignore
+        // it and find slot-2.
+        Files.createDirectories(PoolPaths.slotDir(tmp, 1));
+        int alive = openFake();
+        seedSlot(tmp, 2, alive);
+
+        try (SlotLease lease = leaserFor(tmp).lease()) {
+            assertThat(lease.slotIndex(), equalTo(2));
+        }
+    }
+
+    @Test
+    void releasingLeaseLetsNextLeaserAcquire(@TempDir Path tmp) throws Exception {
+        int alive = openFake();
+        seedSlot(tmp, 1, alive);
+        SlotLeaser leaser = leaserFor(tmp);
+
+        SlotLease first = leaser.lease();
+        assertThat(first.slotIndex(), equalTo(1));
+        first.close();
+
+        try (SlotLease second = leaser.lease()) {
+            assertThat(second.slotIndex(), equalTo(1));
+        }
+    }
+
+    private SlotLeaser leaserFor(Path poolDir) {
+        // Source is null because these tests never trigger grow.
+        return new SlotLeaser(
+                new PoolConfig(poolDir, null, 0,
+                        PoolConfig.DEFAULT_ADMIN_BASE, PoolConfig.DEFAULT_PORT_STRIDE),
+                3L);
+    }
+
+    private void seedSlot(Path poolDir, int idx, int adminPort) throws IOException {
+        Files.createDirectories(PoolPaths.slotDir(poolDir, idx));
+        new SlotPorts(adminPort, adminPort + 1, adminPort + 2, "/fake")
+                .writeTo(PoolPaths.portsFile(poolDir, idx));
+    }
+
+    private int openFake() throws IOException {
+        ServerSocket socket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress());
+        fakes.add(socket);
+        int port = socket.getLocalPort();
+        assertThat(port, greaterThan(0));
+        return port;
+    }
+
+    private int freePort() throws IOException {
+        try (ServerSocket s = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+            return s.getLocalPort();
+        }
+    }
+}

--- a/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/SlotLeaserTest.java
+++ b/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/SlotLeaserTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
+import java.net.Socket;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -137,8 +138,23 @@ class SlotLeaserTest {
     }
 
     private int openFake() throws IOException {
-        ServerSocket socket = new ServerSocket(0, 1, InetAddress.getLoopbackAddress());
+        // Backlog 50 + an accept-and-close drainer thread so health probes can
+        // hit the same fake port repeatedly without filling the listen queue.
+        // Windows enforces backlog strictly: with backlog 1 and no accept(),
+        // the second probe in a row gets refused.
+        ServerSocket socket = new ServerSocket(0, 50, InetAddress.getLoopbackAddress());
         fakes.add(socket);
+        Thread drainer = new Thread(() -> {
+            while (!socket.isClosed()) {
+                try (Socket accepted = socket.accept()) {
+                    // Close immediately — probe just needs the connect to succeed.
+                } catch (IOException e) {
+                    return;
+                }
+            }
+        }, "fake-admin-drainer");
+        drainer.setDaemon(true);
+        drainer.start();
         int port = socket.getLocalPort();
         assertThat(port, greaterThan(0));
         return port;

--- a/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/SlotPortsTest.java
+++ b/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/SlotPortsTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SlotPortsTest {
+
+    @Test
+    void roundTripsThroughDisk(@TempDir Path tmp) throws IOException {
+        Path file = tmp.resolve("ports.properties");
+        SlotPorts original = new SlotPorts(14948, 14949, 14950, "/some/glassfish");
+        original.writeTo(file);
+
+        SlotPorts read = SlotPorts.readFrom(file);
+        assertThat(read.adminPort(), equalTo(14948));
+        assertThat(read.httpPort(), equalTo(14949));
+        assertThat(read.httpsPort(), equalTo(14950));
+        assertThat(read.glassFishHome(), equalTo("/some/glassfish"));
+    }
+
+    @Test
+    void writeIsAtomicallyVisible(@TempDir Path tmp) throws IOException {
+        Path file = tmp.resolve("ports.properties");
+        new SlotPorts(1, 2, 3, "x").writeTo(file);
+        // The .tmp sibling must not be left behind.
+        assertThat(Files.exists(file.resolveSibling("ports.properties.tmp")), equalTo(false));
+    }
+
+    @Test
+    void rejectsMissingProperty(@TempDir Path tmp) throws IOException {
+        Path file = tmp.resolve("partial.properties");
+        Files.writeString(file, "glassfish.adminPort=14948\n");
+        assertThrows(IllegalStateException.class, () -> SlotPorts.readFrom(file));
+    }
+
+    @Test
+    void rejectsNonNumericPort(@TempDir Path tmp) throws IOException {
+        Path file = tmp.resolve("bad.properties");
+        Files.writeString(file,
+                "glassfish.adminPort=oops\n"
+                + "glassfish.httpPort=2\n"
+                + "glassfish.httpsPort=3\n"
+                + "glassfish.home=x\n");
+        assertThrows(IllegalStateException.class, () -> SlotPorts.readFrom(file));
+    }
+}

--- a/integration-tests/src/it/pool/pom.xml
+++ b/integration-tests/src/it/pool/pom.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+
+  The contents of this file are subject to the terms of either the GNU
+  General Public License Version 2 only ("GPL") or the Common Development
+  and Distribution License("CDDL") (collectively, the "License").  You
+  may not use this file except in compliance with the License.  You can
+  obtain a copy of the License at
+  https://github.com/payara/Payara/blob/master/LICENSE.txt
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ee.omnifish.arquillian</groupId>
+        <artifactId>glassfish-containers-main</artifactId>
+        <version>@project.version@</version>
+        <relativePath>../../../..</relativePath>
+    </parent>
+
+    <groupId>ee.omnifish.arquillian.test</groupId>
+    <artifactId>pool-test</artifactId>
+    <packaging>jar</packaging>
+    <name>Integration Test: GlassFish Server Pool</name>
+
+    <description>
+        End-to-end smoke test for arquillian-glassfish-server-pool.
+        Provisions a 1-slot pool via glassfish-pool-maven-plugin, runs an
+        Arquillian deploy-war test against the leased slot, then tears the
+        pool down. Run via integration-tests' maven-invoker harness.
+    </description>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <container.version>@project.version@</container.version>
+        <glassfish.version>@glassfish.version@</glassfish.version>
+        <glassfish.home>@glassfish.home@</glassfish.home>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>ee.omnifish.arquillian</groupId>
+            <artifactId>arquillian-glassfish-server-pool</artifactId>
+            <version>${container.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Stage GlassFish under target/dist so the pool plugin can clone it. -->
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-glassfish</id>
+                        <phase>process-test-classes</phase>
+                        <goals><goal>unpack</goal></goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.glassfish.main.distributions</groupId>
+                                    <artifactId>glassfish</artifactId>
+                                    <version>${glassfish.version}</version>
+                                    <type>zip</type>
+                                    <outputDirectory>${project.build.directory}/dist</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!--
+                Provision/start the pool before failsafe, stop it after.
+                pre-integration-test  -> glassfish-pool:up
+                post-integration-test -> glassfish-pool:down
+            -->
+            <plugin>
+                <groupId>ee.omnifish.arquillian</groupId>
+                <artifactId>glassfish-pool-maven-plugin</artifactId>
+                <version>${container.version}</version>
+                <configuration>
+                    <poolDir>${project.build.directory}/pool</poolDir>
+                    <poolSource>${project.build.directory}/dist/${glassfish.home}</poolSource>
+                    <poolSize>1</poolSize>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>pool-up</id>
+                        <goals><goal>up</goal></goals>
+                    </execution>
+                    <execution>
+                        <id>pool-down</id>
+                        <goals><goal>down</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <systemPropertyVariables>
+                        <gf.pool.dir>${project.build.directory}/pool</gf.pool.dir>
+                    </systemPropertyVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <phase>disabled</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integration-tests/src/it/pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/it/GlassFishPoolDeployWarIT.java
+++ b/integration-tests/src/it/pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/it/GlassFishPoolDeployWarIT.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ */
+package ee.omnifish.arquillian.container.glassfish.pool.it;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * End-to-end smoke test for the pool container: provisions a 1-slot pool
+ * via {@code glassfish-pool:up} (driven by the surrounding pom's plugin
+ * binding), leases the slot through the Arquillian extension, deploys a
+ * war, hits a servlet, undeploys.
+ */
+@ExtendWith(ArquillianExtension.class)
+public class GlassFishPoolDeployWarIT {
+
+    @Deployment(testable = false)
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class, "pool-greet.war")
+                .addClass(GreeterServlet.class);
+    }
+
+    @Test
+    @RunAsClient
+    public void servletRespondsThroughLeasedSlot(@ArquillianResource URL baseURL) throws Exception {
+        URL endpoint = new URL(baseURL, "greet");
+        HttpURLConnection conn = (HttpURLConnection) endpoint.openConnection();
+        conn.setRequestMethod("GET");
+        try (BufferedReader r = new BufferedReader(
+                new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+            String body = r.lines().collect(Collectors.joining());
+            assertThat(body, containsString("Hello from pool slot"));
+        }
+    }
+}

--- a/integration-tests/src/it/pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/it/GreeterServlet.java
+++ b/integration-tests/src/it/pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/it/GreeterServlet.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ */
+package ee.omnifish.arquillian.container.glassfish.pool.it;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@WebServlet(urlPatterns = "/greet")
+public class GreeterServlet extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            throws ServletException, IOException {
+        try (PrintWriter writer = resp.getWriter()) {
+            writer.print("Hello from pool slot");
+        }
+    }
+}

--- a/integration-tests/src/it/pool/src/test/resources/arquillian.xml
+++ b/integration-tests/src/it/pool/src/test/resources/arquillian.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://jboss.org/schema/arquillian"
+    xsi:schemaLocation="http://jboss.org/schema/arquillian https://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <container qualifier="glassfish-pool" default="true">
+        <configuration>
+            <property name="poolDir">${project.build.directory}/pool</property>
+            <property name="leaseTimeoutSeconds">120</property>
+        </configuration>
+    </container>
+
+</arquillian>

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,8 @@
         <module>glassfish-managed</module>
         <module>glassfish-remote</module>
         <module>glassfish-embedded</module>
+        <module>glassfish-pool</module>
+        <module>glassfish-pool-maven-plugin</module>
         <module>glassfish-client-ee10</module>
         <module>glassfish-client-ee11</module>
         <module>integration-tests</module>


### PR DESCRIPTION
Introduces two new modules and an integration test:

- glassfish-pool (arquillian-glassfish-server-pool): pure-Java pool of pre-started GlassFish instances. Test JVMs lease an idle slot via FileChannel.tryLock for the lifetime of the JVM and deploy through the standard CommonGlassFishManager. Slots are cloned from a source install with per-slot port windows (adminBase + (slot-1) * portStride). Replaces the Faces TCK's -javaagent + surefire argLine side-channel.
- glassfish-pool-maven-plugin: lifecycle goals (up/down/provision/status/ nuke) bound by default to pre/post-integration-test, with optional Aether-driven dist staging and modules/ overlays.
- integration-tests/src/it/pool: end-to-end smoke test that provisions a 1-slot pool, deploys a war, hits a servlet, tears down.

Parent pom registers both modules. READMEs document architecture, arquillian.xml setup, full Maven wiring, configuration reference, and troubleshooting for both modules.

For convenience, here are direct links to markdown-parsed READMEs included in this PR:
- [Arquillian Container GlassFish Pool](https://github.com/BalusC/arquillian-container-glassfish/blob/8fdb87909be17b80023d28fae8f76a5c504df092/glassfish-pool/README.md)
- [Arquillian Container GlassFish Pool Maven Plugin](https://github.com/BalusC/arquillian-container-glassfish/blob/8fdb87909be17b80023d28fae8f76a5c504df092/glassfish-pool-maven-plugin/README.md)

Used by https://github.com/jakartaee/faces/pull/2165