### PR TITLE
Support glassfish.systemProperties on glassfish-pool

### DIFF
--- a/glassfish-pool-maven-plugin/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/mojo/AbstractPoolMojo.java
+++ b/glassfish-pool-maven-plugin/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/mojo/AbstractPoolMojo.java
@@ -57,8 +57,22 @@ abstract class AbstractPoolMojo extends AbstractMojo {
     @Parameter(property = "gf.pool.skip", defaultValue = "false")
     protected boolean skip;
 
+    /**
+     * Newline-separated {@code key=value} pairs baked into each slot's
+     * {@code domain.xml} as {@code <jvm-options>-Dkey=value</jvm-options>}.
+     * Mirrors {@code glassfish.systemProperties} on
+     * {@code arquillian-glassfish-server-managed} — same syntax, same
+     * comment ({@code #}) and blank-line handling. Use this for properties
+     * that must be on the GlassFish JVM at startup (e.g.
+     * {@code javax.net.ssl.trustStorePassword}, which a PKCS12 truststore
+     * needs in order to load any trust anchors).
+     */
+    @Parameter(property = "glassfish.systemProperties")
+    protected String systemProperties;
+
     protected PoolConfig poolConfig() {
         Path source = (poolSource == null) ? null : poolSource.toPath();
-        return new PoolConfig(poolDir.toPath(), source, poolSize, adminPortBase, portStride);
+        return new PoolConfig(poolDir.toPath(), source, poolSize, adminPortBase, portStride,
+                PoolConfig.parseSystemProperties(systemProperties));
     }
 }

--- a/glassfish-pool/README.md
+++ b/glassfish-pool/README.md
@@ -194,17 +194,48 @@ These configure the pool layout. The Maven plugin sets them automatically;
 you only need them if you're driving lifecycle from antrun, an IDE, or a
 shell script.
 
-| System property        | Default | Meaning                                                |
-| ---------------------- | ------- | ------------------------------------------------------ |
-| `gf.pool.dir`          | (req)   | Pool root directory.                                   |
-| `gf.pool.source`       | (none)  | Source GlassFish install (template for slot clones).   |
-| `gf.pool.size`         | `1`     | Initial number of slots `up` provisions.               |
-| `gf.pool.adminBase`    | `14848` | Admin port for slot 1.                                 |
-| `gf.pool.portStride`   | `100`   | Per-slot port spacing. Must be ≥ 10.                   |
+| System property            | Default | Meaning                                                |
+| -------------------------- | ------- | ------------------------------------------------------ |
+| `gf.pool.dir`              | (req)   | Pool root directory.                                   |
+| `gf.pool.source`           | (none)  | Source GlassFish install (template for slot clones).   |
+| `gf.pool.size`             | `1`     | Initial number of slots `up` provisions.               |
+| `gf.pool.adminBase`        | `14848` | Admin port for slot 1.                                 |
+| `gf.pool.portStride`       | `100`   | Per-slot port spacing. Must be ≥ 10.                   |
+| `gf.pool.systemProperties` | (none)  | Newline-separated `key=value` jvm options (see below). |
 
 Slot N's admin port = `adminBase + (N-1) * portStride`; HTTP/HTTPS land at
 `+1` and `+2`. The other GlassFish ports (JMX, IIOP, …) are placed within the
 same window by `DomainXmlEditor`.
+
+### Baking system properties into the GlassFish JVM
+
+Some properties have to be on the GF JVM at startup — e.g.
+`javax.net.ssl.trustStorePassword`, which a PKCS12 truststore needs in order
+to load any trust anchors at all. Pass them to the plugin as a multiline
+`<systemProperties>` block (one `key=value` per line; `#` comments and blank
+lines are ignored, mirroring the
+[`arquillian-glassfish-server-managed`](../glassfish-managed/) convention):
+
+```xml
+<plugin>
+    <groupId>ee.omnifish.arquillian</groupId>
+    <artifactId>glassfish-pool-maven-plugin</artifactId>
+    <configuration>
+        <poolDir>${project.build.directory}/pool</poolDir>
+        <poolSource>${project.build.directory}/dist/glassfish9</poolSource>
+        <systemProperties>
+            javax.net.ssl.trustStorePassword=changeit
+            java.awt.headless=true
+        </systemProperties>
+    </configuration>
+    ...
+</plugin>
+```
+
+Each entry becomes a `<jvm-options>-Dkey=value</jvm-options>` child of every
+`<java-config>` in each slot's `domain.xml`, written through the same
+inode-replacing atomic move as port rewrites (so the source install stays
+intact). Override at the command line with `-Dglassfish.systemProperties=…`.
 
 ## Growing on demand (optional)
 

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/DomainXmlEditor.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/DomainXmlEditor.java
@@ -14,6 +14,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -27,6 +29,7 @@ import javax.xml.transform.stream.StreamResult;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
@@ -83,6 +86,88 @@ final class DomainXmlEditor {
             return;
         }
         atomicWrite(domainXml, doc);
+    }
+
+    /**
+     * Upsert {@code -D<key>=<value>} entries into every {@code <java-config>}
+     * block. Each {@code key=value} input becomes/overwrites a
+     * {@code <jvm-options>-Dkey=value</jvm-options>} child of {@code <java-config>}:
+     * <ul>
+     *   <li>existing {@code -Dkey=…} child with same value: left alone (idempotent)</li>
+     *   <li>existing {@code -Dkey=…} child with different value: textContent replaced</li>
+     *   <li>no existing {@code -Dkey=…}: appended as a new child</li>
+     * </ul>
+     *
+     * <p>Empty/null inputs are no-ops. Lines starting with {@code #} and blank
+     * lines have already been filtered upstream (mirrors managed's
+     * {@code glassfish.systemProperties} parsing convention).
+     *
+     * <p>Writes go through the same {@link #atomicWrite atomic-move} path as
+     * {@link #setPorts}, so the source install's hardlinked {@code domain.xml}
+     * stays intact.
+     */
+    static void setJvmOptions(Path domainXml, List<String> properties) throws IOException {
+        if (properties == null || properties.isEmpty()) {
+            return;
+        }
+        Document doc = parse(domainXml);
+        boolean changed = false;
+        NodeList javaConfigs = doc.getElementsByTagName("java-config");
+        for (int i = 0; i < javaConfigs.getLength(); i++) {
+            Element javaConfig = (Element) javaConfigs.item(i);
+            for (String prop : properties) {
+                if (upsertJvmOption(javaConfig, prop)) {
+                    changed = true;
+                }
+            }
+        }
+        if (!changed) {
+            return;
+        }
+        atomicWrite(domainXml, doc);
+    }
+
+    /**
+     * Insert or update one {@code -Dkey=value} entry under a single
+     * {@code <java-config>}. Returns true iff the document changed.
+     */
+    private static boolean upsertJvmOption(Element javaConfig, String keyValue) {
+        String desired = "-D" + keyValue;
+        // Bare key (no value) becomes a flag; match it exactly.
+        // key=value matches by prefix so a stale value gets overwritten.
+        int eq = keyValue.indexOf('=');
+        String prefix = (eq < 0) ? desired : "-D" + keyValue.substring(0, eq + 1);
+        for (Element existing : directChildren(javaConfig, "jvm-options")) {
+            String text = existing.getTextContent();
+            if (text != null && text.startsWith(prefix)) {
+                if (desired.equals(text)) {
+                    return false;
+                }
+                existing.setTextContent(desired);
+                return true;
+            }
+        }
+        Element option = javaConfig.getOwnerDocument().createElement("jvm-options");
+        option.setTextContent(desired);
+        javaConfig.appendChild(option);
+        return true;
+    }
+
+    /**
+     * Direct-child elements with the given tag name. {@code Element.getElementsByTagName}
+     * is recursive; this helper restricts the scan so two {@code <java-config>}
+     * blocks (one per profile) don't see each other's options.
+     */
+    private static List<Element> directChildren(Element parent, String tagName) {
+        List<Element> result = new ArrayList<>();
+        NodeList children = parent.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node n = children.item(i);
+            if (n.getNodeType() == Node.ELEMENT_NODE && tagName.equals(n.getNodeName())) {
+                result.add((Element) n);
+            }
+        }
+        return result;
     }
 
     private static Document parse(Path domainXml) throws IOException {

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolConfig.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolConfig.java
@@ -12,7 +12,10 @@ package ee.omnifish.arquillian.container.glassfish.pool;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * Provisioning-side pool config — used by {@link PoolBootstrap} and the
@@ -38,14 +41,26 @@ public final class PoolConfig {
     public static final String SYS_SIZE = "gf.pool.size";
     public static final String SYS_ADMIN_BASE = "gf.pool.adminBase";
     public static final String SYS_PORT_STRIDE = "gf.pool.portStride";
+    /**
+     * Newline-separated {@code key=value} pairs to bake into each slot's
+     * {@code domain.xml} as {@code <jvm-options>-Dkey=value</jvm-options>}.
+     * Mirrors {@code glassfish.systemProperties} on the managed container.
+     */
+    public static final String SYS_SYSTEM_PROPERTIES = "gf.pool.systemProperties";
 
     private final Path poolDir;
     private final Path source;
     private final int size;
     private final int adminPortBase;
     private final int portStride;
+    private final List<String> systemProperties;
 
     public PoolConfig(Path poolDir, Path source, int size, int adminPortBase, int portStride) {
+        this(poolDir, source, size, adminPortBase, portStride, List.of());
+    }
+
+    public PoolConfig(Path poolDir, Path source, int size, int adminPortBase, int portStride,
+                      List<String> systemProperties) {
         if (portStride < MIN_PORT_STRIDE) {
             throw new IllegalArgumentException(
                     "portStride must be >= " + MIN_PORT_STRIDE + " (got " + portStride + ")");
@@ -55,6 +70,9 @@ public final class PoolConfig {
         this.size = size;
         this.adminPortBase = adminPortBase;
         this.portStride = portStride;
+        this.systemProperties = (systemProperties == null)
+                ? List.of()
+                : Collections.unmodifiableList(List.copyOf(systemProperties));
     }
 
     public Path poolDir() {
@@ -92,6 +110,14 @@ public final class PoolConfig {
     }
 
     /**
+     * Extra {@code -D…} jvm-options to bake into each slot's {@code domain.xml}.
+     * Each entry is a bare {@code key=value} pair (no leading {@code -D}).
+     */
+    public List<String> systemProperties() {
+        return systemProperties;
+    }
+
+    /**
      * Construct from system properties. Used by {@link PoolBootstrap} so a
      * Maven antrun {@code <java>} invocation can pass everything via
      * {@code <sysproperty>} without a CLI dance.
@@ -102,7 +128,24 @@ public final class PoolConfig {
                 pathOrNull(System.getProperty(SYS_SOURCE)),
                 Integer.parseInt(System.getProperty(SYS_SIZE, "1")),
                 Integer.parseInt(System.getProperty(SYS_ADMIN_BASE, String.valueOf(DEFAULT_ADMIN_BASE))),
-                Integer.parseInt(System.getProperty(SYS_PORT_STRIDE, String.valueOf(DEFAULT_PORT_STRIDE))));
+                Integer.parseInt(System.getProperty(SYS_PORT_STRIDE, String.valueOf(DEFAULT_PORT_STRIDE))),
+                parseSystemProperties(System.getProperty(SYS_SYSTEM_PROPERTIES)));
+    }
+
+    /**
+     * Parse a multiline {@code key=value} block into a list. Blank lines and
+     * lines starting with {@code #} are dropped, mirroring managed's
+     * {@code glassfish.systemProperties} convention.
+     */
+    public static List<String> parseSystemProperties(String multiline) {
+        if (multiline == null || multiline.isBlank()) {
+            return List.of();
+        }
+        return multiline.lines()
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .filter(s -> !s.startsWith("#"))
+                        .collect(Collectors.toUnmodifiableList());
     }
 
     private static Path pathOrNull(String s) {

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolProvisioner.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolProvisioner.java
@@ -83,6 +83,7 @@ public final class PoolProvisioner {
                 .resolve("glassfish").resolve("domains").resolve("domain1")
                 .resolve("config").resolve("domain.xml");
         DomainXmlEditor.setPorts(domainXml, adminPort, httpPort, httpsPort);
+        DomainXmlEditor.setJvmOptions(domainXml, config.systemProperties());
 
         AsAdmin asadmin = new AsAdmin(slotInstall);
         try {

--- a/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/DomainXmlEditorTest.java
+++ b/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/DomainXmlEditorTest.java
@@ -5,12 +5,14 @@ package ee.omnifish.arquillian.container.glassfish.pool;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -54,6 +56,87 @@ class DomainXmlEditorTest {
         String content = Files.readString(domainXml);
         assertThat(content, containsString("port=\"${ADMIN_PORT}\""));
         assertThat(content, containsString("port=\"14949\""));
+    }
+
+    private static final String JAVA_CONFIG_FRAGMENT =
+            "<java-config>"
+            + "<jvm-options>-Xmx512m</jvm-options>"
+            + "<jvm-options>-Djavax.net.ssl.trustStore=cacerts.p12</jvm-options>"
+            + "</java-config>";
+
+    @Test
+    void appendsNewJvmOption(@TempDir Path tmp) throws IOException {
+        Path domainXml = tmp.resolve("domain.xml");
+        Files.writeString(domainXml, JAVA_CONFIG_FRAGMENT);
+
+        DomainXmlEditor.setJvmOptions(domainXml,
+                List.of("javax.net.ssl.trustStorePassword=changeit"));
+
+        String content = Files.readString(domainXml);
+        assertThat(content, containsString(
+                "<jvm-options>-Djavax.net.ssl.trustStorePassword=changeit</jvm-options>"));
+        assertThat(content, containsString("<jvm-options>-Xmx512m</jvm-options>"));
+    }
+
+    @Test
+    void replacesExistingJvmOptionWithSameKey(@TempDir Path tmp) throws IOException {
+        Path domainXml = tmp.resolve("domain.xml");
+        Files.writeString(domainXml, JAVA_CONFIG_FRAGMENT);
+
+        DomainXmlEditor.setJvmOptions(domainXml,
+                List.of("javax.net.ssl.trustStore=elsewhere.jks"));
+
+        String content = Files.readString(domainXml);
+        assertThat(content, containsString(
+                "<jvm-options>-Djavax.net.ssl.trustStore=elsewhere.jks</jvm-options>"));
+        assertThat(content, not(containsString(
+                "<jvm-options>-Djavax.net.ssl.trustStore=cacerts.p12</jvm-options>")));
+    }
+
+    @Test
+    void idempotentWhenAlreadySet(@TempDir Path tmp) throws IOException {
+        Path domainXml = tmp.resolve("domain.xml");
+        Files.writeString(domainXml, JAVA_CONFIG_FRAGMENT);
+        long mtimeBefore = Files.getLastModifiedTime(domainXml).toMillis();
+
+        // Sleep just enough that a second write would advance mtime; the
+        // contract is that no write happens, so mtime stays put.
+        try {
+            Thread.sleep(20);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        DomainXmlEditor.setJvmOptions(domainXml,
+                List.of("javax.net.ssl.trustStore=cacerts.p12"));
+
+        long mtimeAfter = Files.getLastModifiedTime(domainXml).toMillis();
+        assertThat(mtimeAfter, equalTo(mtimeBefore));
+    }
+
+    @Test
+    void bareKeyIsIdempotent(@TempDir Path tmp) throws IOException {
+        Path domainXml = tmp.resolve("domain.xml");
+        Files.writeString(domainXml,
+                "<java-config><jvm-options>-Dsomeflag</jvm-options></java-config>");
+
+        DomainXmlEditor.setJvmOptions(domainXml, List.of("someflag"));
+
+        // Should still be a single occurrence — no duplicate appended.
+        String content = Files.readString(domainXml);
+        int count = content.split("-Dsomeflag", -1).length - 1;
+        assertThat(count, equalTo(1));
+    }
+
+    @Test
+    void emptyOrNullPropertiesIsNoop(@TempDir Path tmp) throws IOException {
+        Path domainXml = tmp.resolve("domain.xml");
+        Files.writeString(domainXml, JAVA_CONFIG_FRAGMENT);
+
+        DomainXmlEditor.setJvmOptions(domainXml, List.of());
+        DomainXmlEditor.setJvmOptions(domainXml, null);
+
+        assertThat(Files.readString(domainXml), equalTo(JAVA_CONFIG_FRAGMENT));
     }
 
     @Test

--- a/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/PoolConfigTest.java
+++ b/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/PoolConfigTest.java
@@ -4,6 +4,8 @@
 package ee.omnifish.arquillian.container.glassfish.pool;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -34,5 +36,31 @@ class PoolConfigTest {
         // 10 is the documented minimum (one GF domain occupies 10 ports).
         PoolConfig c = new PoolConfig(Paths.get("/x"), null, 1, 14848, 10);
         assertThat(c.portStride(), equalTo(10));
+    }
+
+    @Test
+    void parseSystemPropertiesStripsBlanksAndComments() {
+        String input = "# leading comment\n"
+                + "javax.net.ssl.trustStorePassword=changeit\n"
+                + "\n"
+                + "  java.awt.headless=true\n"
+                + "# trailing comment\n";
+        assertThat(PoolConfig.parseSystemProperties(input),
+                contains("javax.net.ssl.trustStorePassword=changeit",
+                         "java.awt.headless=true"));
+    }
+
+    @Test
+    void parseSystemPropertiesEmptyForNullOrBlank() {
+        assertThat(PoolConfig.parseSystemProperties(null), empty());
+        assertThat(PoolConfig.parseSystemProperties(""), empty());
+        assertThat(PoolConfig.parseSystemProperties("   \n  \n"), empty());
+    }
+
+    @Test
+    void systemPropertiesPropagatedFromConstructor() {
+        PoolConfig c = new PoolConfig(Paths.get("/x"), null, 1, 14848, 100,
+                java.util.List.of("a=b", "c=d"));
+        assertThat(c.systemProperties(), contains("a=b", "c=d"));
     }
 }


### PR DESCRIPTION
Mirrors the multiline -D jvm-options convention from arquillian-glassfish-server-managed: each `key=value` line in <systemProperties> is upserted into every <java-config> in each slot's domain.xml as <jvm-options>-Dkey=value</jvm-options>, written through the same atomic-move path as setPorts so the source install's hardlinked domain.xml stays intact. Blank/`#` lines are stripped.

Needed for properties that must be on the GF JVM at startup, e.g. javax.net.ssl.trustStorePassword (PKCS12 truststores load zero trust anchors without it). Previously consumers had to hand-edit the source domain.xml via antrun + awk before pool:up cloned slots.

Plugin parameter <systemProperties> on glassfish-pool-maven-plugin, overridable via -Dglassfish.systemProperties=... (matches managed). PoolConfig also reads gf.pool.systemProperties for direct programmatic or antrun <java> use. Existing 5-arg PoolConfig constructor preserved as a delegating overload — no breaking change.

This would simplify https://github.com/jakartaee/security/pull/368 a bit.