### PR TITLE
Promote DomainXmlEditor to glassfish-common

### DIFF
--- a/glassfish-common/src/main/java/ee/omnifish/arquillian/container/glassfish/DomainXmlEditor.java
+++ b/glassfish-common/src/main/java/ee/omnifish/arquillian/container/glassfish/DomainXmlEditor.java
@@ -8,7 +8,7 @@
  * obtain a copy of the License at
  * https://github.com/payara/Payara/blob/master/LICENSE.txt
  */
-package ee.omnifish.arquillian.container.glassfish.pool;
+package ee.omnifish.arquillian.container.glassfish;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -17,7 +17,10 @@ import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
@@ -34,17 +37,21 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 /**
- * DOM-based editor for the per-slot {@code domain.xml}: rewrites the
+ * DOM-based editor for a GlassFish {@code domain.xml}: rewrites the
  * {@code port} attribute on the admin/http/https {@code <network-listener>}
- * elements.
+ * elements, and upserts {@code <jvm-options>} children under each
+ * {@code <java-config>}.
  *
  * <p>Writes go through a sibling tmp file + atomic move so the underlying
- * inode is replaced rather than truncated. That matters because pool slots
- * are produced by hardlinking the source install ({@code Files.createLink}
- * per file); truncating in place would also rewrite the source's
- * {@code domain.xml}, the one that must stay pristine for the next slot.
+ * inode is replaced rather than truncated. That matters for the pool
+ * container, which produces per-slot installs by hardlinking the source
+ * install ({@code Files.createLink} per file); truncating in place would
+ * also rewrite the source's {@code domain.xml}, the one that must stay
+ * pristine for the next slot.
  */
-final class DomainXmlEditor {
+public final class DomainXmlEditor {
+
+    private static final Logger LOG = Logger.getLogger(DomainXmlEditor.class.getName());
 
     private DomainXmlEditor() {
     }
@@ -60,7 +67,7 @@ final class DomainXmlEditor {
      * @param https http-listener-2 port
      * @throws IOException if the file can't be parsed, rewritten, or moved into place
      */
-    static void setPorts(Path domainXml, int admin, int http, int https) throws IOException {
+    public static void setPorts(Path domainXml, int admin, int http, int https) throws IOException {
         Map<String, Integer> wanted = Map.of(
                 "admin-listener", admin,
                 "http-listener-1", http,
@@ -98,15 +105,17 @@ final class DomainXmlEditor {
      *   <li>no existing {@code -Dkey=…}: appended as a new child</li>
      * </ul>
      *
-     * <p>Empty/null inputs are no-ops. Lines starting with {@code #} and blank
-     * lines have already been filtered upstream (mirrors managed's
-     * {@code glassfish.systemProperties} parsing convention).
+     * <p>Inputs are expected to be {@code key=value} (or bare {@code key}) without
+     * the {@code -D} prefix; the editor prepends it. Empty/null inputs are no-ops.
+     * Lines starting with {@code #} and blank lines have already been filtered
+     * upstream (mirrors the {@code glassfish.systemProperties} parsing convention
+     * in {@code CommonGlassFishConfiguration}).
      *
      * <p>Writes go through the same {@link #atomicWrite atomic-move} path as
      * {@link #setPorts}, so the source install's hardlinked {@code domain.xml}
      * stays intact.
      */
-    static void setJvmOptions(Path domainXml, List<String> properties) throws IOException {
+    public static void setSystemProperties(Path domainXml, List<String> properties) throws IOException {
         if (properties == null || properties.isEmpty()) {
             return;
         }
@@ -116,7 +125,7 @@ final class DomainXmlEditor {
         for (int i = 0; i < javaConfigs.getLength(); i++) {
             Element javaConfig = (Element) javaConfigs.item(i);
             for (String prop : properties) {
-                if (upsertJvmOption(javaConfig, prop)) {
+                if (upsertChild(javaConfig, systemPropertyPrefix(prop), "-D" + prop)) {
                     changed = true;
                 }
             }
@@ -128,15 +137,60 @@ final class DomainXmlEditor {
     }
 
     /**
-     * Insert or update one {@code -Dkey=value} entry under a single
-     * {@code <java-config>}. Returns true iff the document changed.
+     * Upsert raw {@code <jvm-options>} entries into every {@code <java-config>}
+     * block. Each map entry is {@code matchPrefix -> fullOption}:
+     * <ul>
+     *   <li>existing child whose text starts with {@code matchPrefix} and equals
+     *       {@code fullOption}: left alone (idempotent)</li>
+     *   <li>existing child whose text starts with {@code matchPrefix} but differs:
+     *       textContent replaced with {@code fullOption}</li>
+     *   <li>no existing child starting with {@code matchPrefix}: {@code fullOption}
+     *       appended as a new child</li>
+     * </ul>
+     *
+     * <p>Use this for options that don't follow the {@code -Dkey=value} convention,
+     * e.g. {@code Map.of("-Xmx", "-Xmx512m", "-ea", "-ea")}. For system properties,
+     * prefer {@link #setSystemProperties}.
+     *
+     * <p>Empty/null inputs are no-ops.
      */
-    private static boolean upsertJvmOption(Element javaConfig, String keyValue) {
-        String desired = "-D" + keyValue;
-        // Bare key (no value) becomes a flag; match it exactly.
-        // key=value matches by prefix so a stale value gets overwritten.
+    public static void setJvmOptions(Path domainXml, Map<String, String> options) throws IOException {
+        if (options == null || options.isEmpty()) {
+            return;
+        }
+        Document doc = parse(domainXml);
+        boolean changed = false;
+        NodeList javaConfigs = doc.getElementsByTagName("java-config");
+        for (int i = 0; i < javaConfigs.getLength(); i++) {
+            Element javaConfig = (Element) javaConfigs.item(i);
+            for (Map.Entry<String, String> entry : options.entrySet()) {
+                if (upsertChild(javaConfig, entry.getKey(), entry.getValue())) {
+                    changed = true;
+                }
+            }
+        }
+        if (!changed) {
+            return;
+        }
+        atomicWrite(domainXml, doc);
+    }
+
+    /**
+     * Match-prefix for a {@code -Dkey=value} option: {@code "-Dkey="} so the
+     * value gets overwritten on update. For a bare {@code key} (no value), the
+     * prefix is the full {@code "-Dkey"} so we only collide with that exact flag.
+     */
+    private static String systemPropertyPrefix(String keyValue) {
         int eq = keyValue.indexOf('=');
-        String prefix = (eq < 0) ? desired : "-D" + keyValue.substring(0, eq + 1);
+        return (eq < 0) ? "-D" + keyValue : "-D" + keyValue.substring(0, eq + 1);
+    }
+
+    /**
+     * Insert or update one {@code <jvm-options>} child under a single
+     * {@code <java-config>}, matching by {@code prefix}. Returns true iff the
+     * document changed.
+     */
+    private static boolean upsertChild(Element javaConfig, String prefix, String desired) {
         for (Element existing : directChildren(javaConfig, "jvm-options")) {
             String text = existing.getTextContent();
             if (text != null && text.startsWith(prefix)) {
@@ -171,18 +225,29 @@ final class DomainXmlEditor {
     }
 
     private static Document parse(Path domainXml) throws IOException {
+        // domain.xml is plain config — no DTDs, no external entities. Harden the
+        // parser per the OWASP XXE cheatsheet so a tampered file can't trigger
+        // entity expansion or external resource fetches.
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-        // domain.xml has no namespaces and pulls no external entities; harden
-        // the parser so a tampered file can't trigger XXE or DOCTYPE expansion.
+        dbf.setValidating(false);
+        dbf.setNamespaceAware(false);
+        dbf.setExpandEntityReferences(false);
         try {
+            dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
             dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            dbf.setXIncludeAware(false);
-            dbf.setExpandEntityReferences(false);
+            unsetAttributeIgnoringIAE(dbf, XMLConstants.ACCESS_EXTERNAL_DTD);
+            unsetAttributeIgnoringIAE(dbf, XMLConstants.ACCESS_EXTERNAL_SCHEMA);
             return dbf.newDocumentBuilder().parse(domainXml.toFile());
         } catch (ParserConfigurationException | SAXException e) {
             throw new IOException("Could not parse " + domainXml, e);
+        }
+    }
+
+    private static void unsetAttributeIgnoringIAE(DocumentBuilderFactory dbf, String name) {
+        try {
+            dbf.setAttribute(name, "");
+        } catch (IllegalArgumentException e) {
+            LOG.log(Level.FINE, () -> "Cannot unset attribute '" + name + "'; falling back to default");
         }
     }
 

--- a/glassfish-common/src/test/java/ee/omnifish/arquillian/container/glassfish/DomainXmlEditorTest.java
+++ b/glassfish-common/src/test/java/ee/omnifish/arquillian/container/glassfish/DomainXmlEditorTest.java
@@ -1,18 +1,17 @@
 /*
  * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
  */
-package ee.omnifish.arquillian.container.glassfish.pool;
+package ee.omnifish.arquillian.container.glassfish;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -37,12 +36,12 @@ class DomainXmlEditorTest {
         DomainXmlEditor.setPorts(domainXml, 14948, 14949, 14950);
 
         String content = Files.readString(domainXml);
-        assertThat(content, containsString("port=\"14948\""));
-        assertThat(content, containsString("port=\"14949\""));
-        assertThat(content, containsString("port=\"14950\""));
-        assertThat(content, not(containsString("port=\"4848\"")));
-        assertThat(content, not(containsString("port=\"8080\"")));
-        assertThat(content, not(containsString("port=\"8181\"")));
+        assertTrue(content.contains("port=\"14948\""), content);
+        assertTrue(content.contains("port=\"14949\""), content);
+        assertTrue(content.contains("port=\"14950\""), content);
+        assertFalse(content.contains("port=\"4848\""), content);
+        assertFalse(content.contains("port=\"8080\""), content);
+        assertFalse(content.contains("port=\"8181\""), content);
     }
 
     @Test
@@ -54,8 +53,8 @@ class DomainXmlEditorTest {
         DomainXmlEditor.setPorts(domainXml, 14948, 14949, 14950);
 
         String content = Files.readString(domainXml);
-        assertThat(content, containsString("port=\"${ADMIN_PORT}\""));
-        assertThat(content, containsString("port=\"14949\""));
+        assertTrue(content.contains("port=\"${ADMIN_PORT}\""), content);
+        assertTrue(content.contains("port=\"14949\""), content);
     }
 
     private static final String JAVA_CONFIG_FRAGMENT =
@@ -65,36 +64,36 @@ class DomainXmlEditorTest {
             + "</java-config>";
 
     @Test
-    void appendsNewJvmOption(@TempDir Path tmp) throws IOException {
+    void appendsNewSystemProperty(@TempDir Path tmp) throws IOException {
         Path domainXml = tmp.resolve("domain.xml");
         Files.writeString(domainXml, JAVA_CONFIG_FRAGMENT);
 
-        DomainXmlEditor.setJvmOptions(domainXml,
+        DomainXmlEditor.setSystemProperties(domainXml,
                 List.of("javax.net.ssl.trustStorePassword=changeit"));
 
         String content = Files.readString(domainXml);
-        assertThat(content, containsString(
-                "<jvm-options>-Djavax.net.ssl.trustStorePassword=changeit</jvm-options>"));
-        assertThat(content, containsString("<jvm-options>-Xmx512m</jvm-options>"));
+        assertTrue(content.contains(
+                "<jvm-options>-Djavax.net.ssl.trustStorePassword=changeit</jvm-options>"), content);
+        assertTrue(content.contains("<jvm-options>-Xmx512m</jvm-options>"), content);
     }
 
     @Test
-    void replacesExistingJvmOptionWithSameKey(@TempDir Path tmp) throws IOException {
+    void replacesExistingSystemPropertyWithSameKey(@TempDir Path tmp) throws IOException {
         Path domainXml = tmp.resolve("domain.xml");
         Files.writeString(domainXml, JAVA_CONFIG_FRAGMENT);
 
-        DomainXmlEditor.setJvmOptions(domainXml,
+        DomainXmlEditor.setSystemProperties(domainXml,
                 List.of("javax.net.ssl.trustStore=elsewhere.jks"));
 
         String content = Files.readString(domainXml);
-        assertThat(content, containsString(
-                "<jvm-options>-Djavax.net.ssl.trustStore=elsewhere.jks</jvm-options>"));
-        assertThat(content, not(containsString(
-                "<jvm-options>-Djavax.net.ssl.trustStore=cacerts.p12</jvm-options>")));
+        assertTrue(content.contains(
+                "<jvm-options>-Djavax.net.ssl.trustStore=elsewhere.jks</jvm-options>"), content);
+        assertFalse(content.contains(
+                "<jvm-options>-Djavax.net.ssl.trustStore=cacerts.p12</jvm-options>"), content);
     }
 
     @Test
-    void idempotentWhenAlreadySet(@TempDir Path tmp) throws IOException {
+    void systemPropertyIsIdempotentWhenAlreadySet(@TempDir Path tmp) throws IOException {
         Path domainXml = tmp.resolve("domain.xml");
         Files.writeString(domainXml, JAVA_CONFIG_FRAGMENT);
         long mtimeBefore = Files.getLastModifiedTime(domainXml).toMillis();
@@ -107,36 +106,88 @@ class DomainXmlEditorTest {
             Thread.currentThread().interrupt();
         }
 
-        DomainXmlEditor.setJvmOptions(domainXml,
+        DomainXmlEditor.setSystemProperties(domainXml,
                 List.of("javax.net.ssl.trustStore=cacerts.p12"));
 
         long mtimeAfter = Files.getLastModifiedTime(domainXml).toMillis();
-        assertThat(mtimeAfter, equalTo(mtimeBefore));
+        assertEquals(mtimeBefore, mtimeAfter);
     }
 
     @Test
-    void bareKeyIsIdempotent(@TempDir Path tmp) throws IOException {
+    void bareSystemPropertyKeyIsIdempotent(@TempDir Path tmp) throws IOException {
         Path domainXml = tmp.resolve("domain.xml");
         Files.writeString(domainXml,
                 "<java-config><jvm-options>-Dsomeflag</jvm-options></java-config>");
 
-        DomainXmlEditor.setJvmOptions(domainXml, List.of("someflag"));
+        DomainXmlEditor.setSystemProperties(domainXml, List.of("someflag"));
 
         // Should still be a single occurrence — no duplicate appended.
         String content = Files.readString(domainXml);
         int count = content.split("-Dsomeflag", -1).length - 1;
-        assertThat(count, equalTo(1));
+        assertEquals(1, count);
     }
 
     @Test
-    void emptyOrNullPropertiesIsNoop(@TempDir Path tmp) throws IOException {
+    void emptyOrNullSystemPropertiesIsNoop(@TempDir Path tmp) throws IOException {
         Path domainXml = tmp.resolve("domain.xml");
         Files.writeString(domainXml, JAVA_CONFIG_FRAGMENT);
 
-        DomainXmlEditor.setJvmOptions(domainXml, List.of());
+        DomainXmlEditor.setSystemProperties(domainXml, List.of());
+        DomainXmlEditor.setSystemProperties(domainXml, null);
+
+        assertEquals(JAVA_CONFIG_FRAGMENT, Files.readString(domainXml));
+    }
+
+    @Test
+    void replacesExistingJvmOptionByPrefix(@TempDir Path tmp) throws IOException {
+        Path domainXml = tmp.resolve("domain.xml");
+        Files.writeString(domainXml, JAVA_CONFIG_FRAGMENT);
+
+        DomainXmlEditor.setJvmOptions(domainXml, Map.of("-Xmx", "-Xmx2g"));
+
+        String content = Files.readString(domainXml);
+        assertTrue(content.contains("<jvm-options>-Xmx2g</jvm-options>"), content);
+        assertFalse(content.contains("<jvm-options>-Xmx512m</jvm-options>"), content);
+    }
+
+    @Test
+    void appendsNewJvmOptionWhenAbsent(@TempDir Path tmp) throws IOException {
+        Path domainXml = tmp.resolve("domain.xml");
+        Files.writeString(domainXml, JAVA_CONFIG_FRAGMENT);
+
+        DomainXmlEditor.setJvmOptions(domainXml, Map.of("-ea", "-ea"));
+
+        String content = Files.readString(domainXml);
+        assertTrue(content.contains("<jvm-options>-ea</jvm-options>"), content);
+    }
+
+    @Test
+    void jvmOptionIsIdempotentWhenAlreadySet(@TempDir Path tmp) throws IOException {
+        Path domainXml = tmp.resolve("domain.xml");
+        Files.writeString(domainXml, JAVA_CONFIG_FRAGMENT);
+        long mtimeBefore = Files.getLastModifiedTime(domainXml).toMillis();
+
+        try {
+            Thread.sleep(20);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        DomainXmlEditor.setJvmOptions(domainXml, Map.of("-Xmx", "-Xmx512m"));
+
+        long mtimeAfter = Files.getLastModifiedTime(domainXml).toMillis();
+        assertEquals(mtimeBefore, mtimeAfter);
+    }
+
+    @Test
+    void emptyOrNullJvmOptionsIsNoop(@TempDir Path tmp) throws IOException {
+        Path domainXml = tmp.resolve("domain.xml");
+        Files.writeString(domainXml, JAVA_CONFIG_FRAGMENT);
+
+        DomainXmlEditor.setJvmOptions(domainXml, Map.of());
         DomainXmlEditor.setJvmOptions(domainXml, null);
 
-        assertThat(Files.readString(domainXml), equalTo(JAVA_CONFIG_FRAGMENT));
+        assertEquals(JAVA_CONFIG_FRAGMENT, Files.readString(domainXml));
     }
 
     @Test
@@ -159,8 +210,8 @@ class DomainXmlEditorTest {
 
         String slotContent = Files.readString(slot);
         String sourceContent = Files.readString(source);
-        assertThat(slotContent, containsString("port=\"14948\""));
-        assertThat(sourceContent, containsString("port=\"4848\""));
-        assertThat(sourceContent.equals(slotContent), is(false));
+        assertTrue(slotContent.contains("port=\"14948\""), slotContent);
+        assertTrue(sourceContent.contains("port=\"4848\""), sourceContent);
+        assertFalse(sourceContent.equals(slotContent));
     }
 }

--- a/glassfish-managed/src/main/java/ee/omnifish/arquillian/container/glassfish/managed/GlassFishServerControl.java
+++ b/glassfish-managed/src/main/java/ee/omnifish/arquillian/container/glassfish/managed/GlassFishServerControl.java
@@ -66,13 +66,11 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.jboss.arquillian.container.spi.client.container.LifecycleException;
 
+import ee.omnifish.arquillian.container.glassfish.DomainXmlEditor;
 import ee.omnifish.arquillian.container.glassfish.process.CloseableProcess;
 import ee.omnifish.arquillian.container.glassfish.process.ConsoleReader;
 import ee.omnifish.arquillian.container.glassfish.process.OutputLoggingConsumer;
@@ -80,8 +78,6 @@ import ee.omnifish.arquillian.container.glassfish.process.ProcessOutputConsumer;
 import ee.omnifish.arquillian.container.glassfish.process.SilentOutputConsumer;
 
 import static java.lang.Runtime.getRuntime;
-import static java.nio.file.Files.readString;
-import static java.nio.file.Files.writeString;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.copyOfRange;
 import static java.util.logging.Level.SEVERE;
@@ -119,24 +115,7 @@ class GlassFishServerControl {
             startDerbyDatabase();
         }
 
-        Map<String, String> vmOptions = new LinkedHashMap<String, String>();
-        if (config.getMaxHeapSize() != null) {
-            vmOptions.put("-Xmx", config.getMaxHeapSize());
-        }
-
-        if (config.getEnableAssertions() != null) {
-            vmOptions.put("-ea", config.getEnableAssertions());
-        }
-
-        for (String systemProperty : config.getSystemProperyList()) {
-            vmOptions.put("-D" + systemProperty, "");
-        }
-
-        if (!vmOptions.isEmpty()) {
-            setVmOptionsInDomain(vmOptions);
-        }
-
-        setPortsInDomain(config.getAdminPort(), config.getHttpPort(), config.getHttpsPort());
+        applyDomainXmlEdits();
 
         final List<String> args = new ArrayList<>();
         if (config.isDebug()) {
@@ -244,70 +223,24 @@ class GlassFishServerControl {
         getRuntime().addShutdownHook(shutdownHook);
     }
 
-    private void setVmOptionsInDomain(Map<String, String> vmOptions) {
-        // Quick and dirty replacements via regexp for now.
-        // Eventually a fully parsed domain.xml editing may be better.
+    private void applyDomainXmlEdits() {
+        Path domainXml = Paths.get(config.getDomainXmlPath());
         try {
-            String content = readString(Paths.get(config.getDomainXmlPath()));
+            DomainXmlEditor.setPorts(domainXml, config.getAdminPort(), config.getHttpPort(), config.getHttpsPort());
 
-            for (Entry<String, String> vmOption :  vmOptions.entrySet()) {
-
-                Matcher vmOptionMatcher = Pattern.compile("<jvm-options>" + Pattern.quote(vmOption.getKey()) + "(.*)</jvm-options>")
-                                                 .matcher(content);
-
-                if (vmOptionMatcher.find()) {
-                    content  = vmOptionMatcher.replaceAll("<jvm-options>" + vmOption.getKey() + vmOption.getValue() + "</jvm-options>");
-                } else {
-                    content  = content.replaceAll(
-                                    "</java-config>",
-                                    "<jvm-options>" + vmOption.getKey() + vmOption.getValue() + "</jvm-options>\n</java-config>");
-                }
+            Map<String, String> jvmOptions = new LinkedHashMap<>();
+            if (config.getMaxHeapSize() != null) {
+                jvmOptions.put("-Xmx", "-Xmx" + config.getMaxHeapSize());
             }
+            if (config.getEnableAssertions() != null) {
+                jvmOptions.put("-ea", "-ea" + config.getEnableAssertions());
+            }
+            DomainXmlEditor.setJvmOptions(domainXml, jvmOptions);
 
-            writeString(Paths.get(config.getDomainXmlPath()), content);
+            DomainXmlEditor.setSystemProperties(domainXml, config.getSystemProperyList());
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.log(SEVERE, "Failed editing " + domainXml, e);
         }
-    }
-
-    private void setPortsInDomain(int adminPort, int httpPort, int httpsPort) {
-        // Quick and dirty replacements via regexp for now.
-        // Eventually a fully parsed domain.xml editing may be better.
-        try {
-            String content = readString(Paths.get(config.getDomainXmlPath()));
-            boolean contentChanged = false;
-
-            String newContent = null;
-
-            for (var entry : Map.of("admin-listener", adminPort, "http-listener-1", httpPort, "http-listener-2", httpsPort).entrySet()) {
-                newContent = updateNetworkListener(content, entry.getKey(), entry.getValue());
-                if (newContent != null) {
-                    content = newContent;
-                    contentChanged = true;
-                }
-            }
-
-            if (contentChanged) {
-                writeString(Paths.get(config.getDomainXmlPath()), content);
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
-    private String updateNetworkListener(String domainXml, String name, int port) {
-        Matcher networkMatcher = Pattern.compile("(<network-listener.* port=\\\")(.*?)(\\\" .*" + name + ".*>)")
-                                     .matcher(domainXml);
-
-        if (networkMatcher.find()) {
-            String originalPort = networkMatcher.group(2);
-            if (!originalPort.startsWith("${") && !originalPort.equals(port + "")) {
-                return networkMatcher.replaceAll("$1" + port + "$3");
-            }
-        }
-
-        return null;
-
     }
 
     private void executeAdminDomainCommand(String description, String adminCmd, List<String> args, ProcessOutputConsumer consumer) throws LifecycleException {

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolProvisioner.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolProvisioner.java
@@ -19,6 +19,8 @@ import java.util.Comparator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import ee.omnifish.arquillian.container.glassfish.DomainXmlEditor;
+
 /**
  * Provisions a single slot: clone the source install, patch the per-slot
  * ports into {@code domain.xml}, run {@code asadmin start-domain}, then
@@ -83,7 +85,7 @@ public final class PoolProvisioner {
                 .resolve("glassfish").resolve("domains").resolve("domain1")
                 .resolve("config").resolve("domain.xml");
         DomainXmlEditor.setPorts(domainXml, adminPort, httpPort, httpsPort);
-        DomainXmlEditor.setJvmOptions(domainXml, config.systemProperties());
+        DomainXmlEditor.setSystemProperties(domainXml, config.systemProperties());
 
         AsAdmin asadmin = new AsAdmin(slotInstall);
         try {

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolSourceCloner.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolSourceCloner.java
@@ -19,6 +19,8 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.logging.Logger;
 
+import ee.omnifish.arquillian.container.glassfish.DomainXmlEditor;
+
 /**
  * Clones a source GlassFish install tree into a slot directory using
  * {@link Files#createLink hardlinks} so N slots cost ~one source's worth


### PR DESCRIPTION
## Summary

- Moves the JAXP-based `DomainXmlEditor` from `glassfish-pool` (package-private) up to `glassfish-common` as a public type, so both pool and managed containers share one implementation.
- Replaces the regex-based `domain.xml` rewriting in `glassfish-managed`'s `GlassFishServerControl` (`setVmOptionsInDomain` / `setPortsInDomain` / `updateNetworkListener`) with calls to it.
- Aligns the parser's XXE hardening to the OmniFaces `Xml.java` recipe (`FEATURE_SECURE_PROCESSING` + `disallow-doctype-decl` + empty `ACCESS_EXTERNAL_DTD` / `ACCESS_EXTERNAL_SCHEMA`).

## API

- `setPorts(Path, int, int, int)`
- `setSystemProperties(Path, List<String>)` — `-D` prepended (renamed from the pool's `setJvmOptions`)
- `setJvmOptions(Path, Map<String, String>)` — generic, `matchPrefix -> fullOption`, for raw options like `-Xmx512m` or `-ea`

## History

`DomainXmlEditor` was first introduced in `glassfish-pool` by copying the regex-based code out of `GlassFishServerControl` verbatim, then migrated to JAXP DOM for robustness against attribute reordering, whitespace, and a duplicate-append bug in the regex sysprop path. `glassfish-managed` kept the original regex copy until now. This PR finishes the round trip.

## Side effects of the managed-side migration

- System-property upsert is now prefix-matched on `-Dkey=`; the old regex matched the full `-Dkey=value`, so re-running with a changed value appended a duplicate instead of overwriting.
- Listener-port matching no longer relies on the regex's attribute-order assumption.
- `IOException` from the edit is now logged at `SEVERE` instead of being swallowed via `e.printStackTrace()`.

## Tests

- 12 unit tests for `DomainXmlEditor` (moved alongside the class, rewritten in plain JUnit Jupiter so `glassfish-common` doesn't need to pull in hamcrest), with new coverage for the `setJvmOptions(Map)` form.
