### PR TITLE
Add restartOnRelease option to recycle leased GF JVM on stop

### DIFF
--- a/glassfish-pool-maven-plugin/README.md
+++ b/glassfish-pool-maven-plugin/README.md
@@ -3,9 +3,9 @@
 Maven plugin that drives the lifecycle of an
 [`arquillian-glassfish-server-pool`](../glassfish-pool/) pool. Binds
 naturally to `pre-integration-test` / `post-integration-test` so a
-consumer pom only has to add three plugin blocks (this one, dependency
-unpack, and failsafe) to get a parallel-fork-friendly pool of GlassFish
-instances.
+consumer pom only has to add two plugin blocks (this one with a
+`<distribution>` element, and failsafe) to get a parallel-fork-friendly
+pool of GlassFish instances.
 
 | Coordinates  | Value                              |
 | ------------ | ---------------------------------- |
@@ -26,18 +26,25 @@ instances.
 
 ## Quick start
 
-Bind `up` and `down` to the integration-test phases, point `failsafe` at the
-same `poolDir`, and run `mvn verify`:
+Bind `up` and `down` to the integration-test phases, declare a
+`<distribution>` so the plugin resolves and unpacks GlassFish itself,
+point `failsafe` at the same `poolDir`, and run `mvn verify`:
 
 ```xml
 <plugin>
     <groupId>ee.omnifish.arquillian</groupId>
     <artifactId>glassfish-pool-maven-plugin</artifactId>
-    <version>2.1.4</version>
+    <version>2.2.0</version>
     <configuration>
         <poolDir>${project.build.directory}/pool</poolDir>
         <poolSource>${project.build.directory}/dist/glassfish9</poolSource>
         <poolSize>4</poolSize>
+        <distribution>
+            <groupId>org.glassfish.main.distributions</groupId>
+            <artifactId>glassfish</artifactId>
+            <version>9.0.0</version>
+            <type>zip</type>
+        </distribution>
     </configuration>
     <executions>
         <execution><id>pool-up</id><goals><goal>up</goal></goals></execution>
@@ -46,13 +53,13 @@ same `poolDir`, and run `mvn verify`:
 </plugin>
 ```
 
-For the full three-plugin wiring (dependency unpack + this plugin +
-failsafe), see [`../glassfish-pool/README.md`](../glassfish-pool/README.md#end-to-end-maven-setup).
+For the failsafe side (`gf.pool.dir` forwarding, parallel forks, the
+`arquillian.xml` setup), see
+[`../glassfish-pool/README.md`](../glassfish-pool/README.md#end-to-end-maven-setup).
 
-The plugin does **not** download a GlassFish distribution unless you supply
-the `<distribution>` block (see *Auto-staging*). Most builds let
-`maven-dependency-plugin` unpack into `${project.build.directory}/dist` and
-point `poolSource` at the result.
+If your build already runs `maven-dependency-plugin` for unrelated reasons,
+drop `<distribution>` and let the existing `unpack` execution land the dist
+at `${project.build.directory}/dist` — see *Bring your own unpack* below.
 
 ## Configuration reference
 
@@ -86,39 +93,47 @@ build isn't running tests there's no reason to pay for a pool.
 
 `provision` additionally requires `-Dgf.pool.slot=N`.
 
-## Auto-staging (skip the dependency-plugin block)
+## Staging behaviour
 
-If you'd rather have the plugin resolve the dist itself — useful for TCK-style
-builds that swap GlassFish versions per profile — declare a `<distribution>`
-block. The plugin uses Aether to resolve the artifact through your usual
-repositories and unpacks it under `<stageDir>` before provisioning runs.
+The plugin uses Aether to resolve `<distribution>` through your usual
+repositories and unpacks it under `<stageDir>`
+(default `${project.build.directory}/dist`) before provisioning runs.
+Staging runs once per pool — re-runs fast-exit when the marker file
+written after a successful unpack is still present. Set
+`<unpackSkip>true</unpackSkip>` to short-circuit the check entirely.
+
+### Bring your own unpack
+
+If your build already runs `maven-dependency-plugin` for unrelated reasons,
+drop the `<distribution>` block from this plugin and add a regular `unpack`
+execution that lands the dist in the same directory `<poolSource>` points at:
 
 ```xml
 <plugin>
-    <groupId>ee.omnifish.arquillian</groupId>
-    <artifactId>glassfish-pool-maven-plugin</artifactId>
-    <version>2.1.4</version>
-    <configuration>
-        <poolDir>${project.build.directory}/pool</poolDir>
-        <poolSource>${project.build.directory}/dist/glassfish9</poolSource>
-        <poolSize>4</poolSize>
-        <distribution>
-            <groupId>org.glassfish.main.distributions</groupId>
-            <artifactId>glassfish</artifactId>
-            <version>9.0.0</version>
-            <type>zip</type>
-        </distribution>
-    </configuration>
+    <artifactId>maven-dependency-plugin</artifactId>
     <executions>
-        <execution><id>pool-up</id><goals><goal>up</goal></goals></execution>
-        <execution><id>pool-down</id><goals><goal>down</goal></goals></execution>
+        <execution>
+            <id>unpack-glassfish</id>
+            <phase>process-test-classes</phase>
+            <goals><goal>unpack</goal></goals>
+            <configuration>
+                <artifactItems>
+                    <artifactItem>
+                        <groupId>org.glassfish.main.distributions</groupId>
+                        <artifactId>glassfish</artifactId>
+                        <version>9.0.0</version>
+                        <type>zip</type>
+                        <outputDirectory>${project.build.directory}/dist</outputDirectory>
+                    </artifactItem>
+                </artifactItems>
+            </configuration>
+        </execution>
     </executions>
 </plugin>
 ```
 
-Staging runs once per pool — re-runs fast-exit when the marker file written
-after a successful unpack is still present. Set `<unpackSkip>true</unpackSkip>`
-to short-circuit the check entirely.
+The pool plugin will then skip staging and clone slots directly from
+`${project.build.directory}/dist/glassfish9`.
 
 ## Overlays
 

--- a/glassfish-pool/README.md
+++ b/glassfish-pool/README.md
@@ -90,9 +90,9 @@ which is what the integration tests do — see [`integration-tests/src/it/pool`]
 
 ## End-to-end Maven setup
 
-Wiring the pool into a build is three plugin blocks: stage GlassFish, run
-`glassfish-pool:up` before `failsafe:integration-test`, forward `gf.pool.dir`
-to the test JVMs.
+Two plugin blocks: the pool plugin (which resolves and unpacks GlassFish
+itself via its `<distribution>` element), and failsafe pointed at the
+same `poolDir`.
 
 ```xml
 <properties>
@@ -102,38 +102,21 @@ to the test JVMs.
 
 <build>
     <plugins>
-        <!-- 1. Unpack a GlassFish dist; the pool will clone from this. -->
-        <plugin>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-                <execution>
-                    <id>unpack-glassfish</id>
-                    <phase>process-test-classes</phase>
-                    <goals><goal>unpack</goal></goals>
-                    <configuration>
-                        <artifactItems>
-                            <artifactItem>
-                                <groupId>org.glassfish.main.distributions</groupId>
-                                <artifactId>glassfish</artifactId>
-                                <version>${glassfish.version}</version>
-                                <type>zip</type>
-                                <outputDirectory>${project.build.directory}/dist</outputDirectory>
-                            </artifactItem>
-                        </artifactItems>
-                    </configuration>
-                </execution>
-            </executions>
-        </plugin>
-
-        <!-- 2. Provision/start the pool before failsafe; tear it down after. -->
+        <!-- 1. Provision/start the pool before failsafe; tear it down after. -->
         <plugin>
             <groupId>ee.omnifish.arquillian</groupId>
             <artifactId>glassfish-pool-maven-plugin</artifactId>
-            <version>2.1.4</version>
+            <version>2.2.0</version>
             <configuration>
                 <poolDir>${project.build.directory}/pool</poolDir>
                 <poolSource>${project.build.directory}/dist/glassfish9</poolSource>
                 <poolSize>${pool.size}</poolSize>
+                <distribution>
+                    <groupId>org.glassfish.main.distributions</groupId>
+                    <artifactId>glassfish</artifactId>
+                    <version>${glassfish.version}</version>
+                    <type>zip</type>
+                </distribution>
             </configuration>
             <executions>
                 <execution><id>pool-up</id><goals><goal>up</goal></goals></execution>
@@ -141,7 +124,7 @@ to the test JVMs.
             </executions>
         </plugin>
 
-        <!-- 3. Forward gf.pool.dir to test JVMs, run tests in parallel forks. -->
+        <!-- 2. Forward gf.pool.dir to test JVMs, run tests in parallel forks. -->
         <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
@@ -161,6 +144,11 @@ to the test JVMs.
 </build>
 ```
 
+The plugin resolves `<distribution>` through your usual Maven repositories
+and unpacks the zip under `${project.build.directory}/dist` before
+provisioning runs. Staging is idempotent: re-runs fast-exit when the
+marker file written after a successful unpack is still present.
+
 Run it:
 
 ```
@@ -169,6 +157,40 @@ mvn verify
 
 For per-class fork parallelism across `${pool.size}` slots, that's all you
 need. To go wider than `${pool.size}`, see *Growing on demand* below.
+
+### Bring your own unpack
+
+If your build already runs `maven-dependency-plugin` for unrelated reasons,
+drop the `<distribution>` block from the pool plugin and let the existing
+`unpack` execution land the dist in the same directory `<poolSource>`
+points at:
+
+```xml
+<plugin>
+    <artifactId>maven-dependency-plugin</artifactId>
+    <executions>
+        <execution>
+            <id>unpack-glassfish</id>
+            <phase>process-test-classes</phase>
+            <goals><goal>unpack</goal></goals>
+            <configuration>
+                <artifactItems>
+                    <artifactItem>
+                        <groupId>org.glassfish.main.distributions</groupId>
+                        <artifactId>glassfish</artifactId>
+                        <version>${glassfish.version}</version>
+                        <type>zip</type>
+                        <outputDirectory>${project.build.directory}/dist</outputDirectory>
+                    </artifactItem>
+                </artifactItems>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+```
+
+The pool plugin will then skip staging and clone slots directly from
+`${project.build.directory}/dist/glassfish9`.
 
 ## Configuration reference
 

--- a/glassfish-pool/README.md
+++ b/glassfish-pool/README.md
@@ -174,15 +174,16 @@ need. To go wider than `${pool.size}`, see *Growing on demand* below.
 
 ### Test-JVM configuration (`arquillian.xml` properties)
 
-| Property              | Type   | Default                  | Notes                                                   |
-| --------------------- | ------ | ------------------------ | ------------------------------------------------------- |
-| `poolDir`             | String | `-Dgf.pool.dir`          | Required. Must match the build's `poolDir`.             |
-| `leaseTimeoutSeconds` | long   | `600`                    | Lease wait before failing the test JVM.                 |
-| `adminUser`           | String | `admin`                  | Inherited from `CommonGlassFishConfiguration`.          |
-| `adminPassword`       | String | (empty)                  | Inherited.                                              |
-| `httpPort`            | int    | overwritten at lease     | Set from the slot's `ports.properties`.                 |
-| `httpsPort`           | int    | overwritten at lease     | Set from the slot's `ports.properties`.                 |
-| `glassFishHome`       | String | overwritten at lease     | Set from the slot's `ports.properties`.                 |
+| Property              | Type    | Default                          | Notes                                                                                                       |
+| --------------------- | ------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `poolDir`             | String  | `-Dgf.pool.dir`                  | Required. Must match the build's `poolDir`.                                                                 |
+| `leaseTimeoutSeconds` | long    | `600`                            | Lease wait before failing the test JVM.                                                                     |
+| `restartOnRelease`    | boolean | `-Dgf.pool.restartOnRelease`/`false` | Restart GF on the leased slot before releasing the lock. See [Restarting GlassFish between tests](#restarting-glassfish-between-tests). |
+| `adminUser`           | String  | `admin`                          | Inherited from `CommonGlassFishConfiguration`.                                                              |
+| `adminPassword`       | String  | (empty)                          | Inherited.                                                                                                  |
+| `httpPort`            | int     | overwritten at lease             | Set from the slot's `ports.properties`.                                                                     |
+| `httpsPort`           | int     | overwritten at lease             | Set from the slot's `ports.properties`.                                                                     |
+| `glassFishHome`       | String  | overwritten at lease             | Set from the slot's `ports.properties`.                                                                     |
 
 `adminHost`/`adminPort` are also overwritten at lease time. Anything you set
 in `arquillian.xml` for those four host/port fields is informational only —
@@ -202,6 +203,7 @@ shell script.
 | `gf.pool.adminBase`        | `14848` | Admin port for slot 1.                                 |
 | `gf.pool.portStride`       | `100`   | Per-slot port spacing. Must be ≥ 10.                   |
 | `gf.pool.systemProperties` | (none)  | Newline-separated `key=value` jvm options (see below). |
+| `gf.pool.restartOnRelease` | `false` | Seeds `restartOnRelease` for every test JVM the build forks. |
 
 Slot N's admin port = `adminBase + (N-1) * portStride`; HTTP/HTTPS land at
 `+1` and `+2`. The other GlassFish ports (JMX, IIOP, …) are placed within the
@@ -252,6 +254,94 @@ deadlock. To enable, add to `failsafe`'s `<systemPropertyVariables>`:
 Without `gf.pool.source` the leaser still works against the existing pool —
 it just blocks for an idle slot instead of growing one. That's the right
 default when `forkCount` ≤ `poolSize`.
+
+## Restarting GlassFish between tests (optional)
+
+By default a slot's GlassFish JVM survives across the test JVMs that lease
+it — only the deployments come and go. That's fine for most suites, but
+some tests leak JVM-scoped state that `undeploy` alone doesn't clear:
+classloader pins, datasource pool handles, ThreadLocals, EclipseLink
+session caches, etc. Set `restartOnRelease=true` and the container will
+run `asadmin restart-domain domain1` against the leased slot's install
+just before the lock is released, so the next leaser sees a fresh GF
+JVM on the same ports.
+
+The flag is exposed at three layers of increasing granularity. Pick the
+narrowest one that fits.
+
+### 1. Build-wide default (parent pom)
+
+Forward the sysprop to every test JVM the build forks. This is also the
+right place to set the *default* the build ships with — individual
+modules can override it later.
+
+```xml
+<properties>
+    <gf.pool.restartOnRelease>false</gf.pool.restartOnRelease>
+</properties>
+
+<plugin>
+    <artifactId>maven-failsafe-plugin</artifactId>
+    <configuration>
+        <systemPropertyVariables>
+            <gf.pool.dir>${project.build.directory}/pool</gf.pool.dir>
+            <gf.pool.source>${project.build.directory}/dist/glassfish9</gf.pool.source>
+            <gf.pool.restartOnRelease>${gf.pool.restartOnRelease}</gf.pool.restartOnRelease>
+        </systemPropertyVariables>
+    </configuration>
+</plugin>
+```
+
+Forwarding `gf.pool.source` is strongly recommended when this is on: if a
+restart fails, the next leaser's port-health probe marks the slot dead and
+`tryGrow` recycles it by re-provisioning from `gf.pool.source`. Without a
+source forwarded, a failed restart leaves a permanently dead slot.
+
+### 2. Per-module override (child pom)
+
+With the parent's failsafe block forwarding `${gf.pool.restartOnRelease}`,
+any child module can flip the flag for its own test JVMs by overriding
+the Maven property:
+
+```xml
+<!-- e.g. a stateful-EJB module that leaks JDBC pool handles -->
+<properties>
+    <gf.pool.restartOnRelease>true</gf.pool.restartOnRelease>
+</properties>
+```
+
+No other change needed — surefire/failsafe interpolation picks up the
+local value automatically.
+
+### 3. Per-arquillian.xml (one container declaration)
+
+If a module has its own `src/test/resources/arquillian.xml` (test
+resources win over inherited ones on the classpath), the flag can be
+set right next to `poolDir`:
+
+```xml
+<container qualifier="glassfish-pool" default="true">
+    <configuration>
+        <property name="poolDir">${gf.pool.dir}</property>
+        <property name="restartOnRelease">true</property>
+    </configuration>
+</container>
+```
+
+This overrides whatever sysprop default the build forwarded for the
+test JVMs that resolve this `arquillian.xml`.
+
+### Cost and safety
+
+Restart adds the GF cold-start cost (typically 5–15 s) to each lease
+release. On a `forkCount=4`, hundreds-of-test-class suite this can be
+significant — measure before enabling globally. The restart is bounded
+to a 90 s timeout; if it times out, the asadmin process is force-killed,
+the lease releases anyway, and the next leaser will recycle the slot.
+
+The container holds the slot's file lock *during* the restart, so a
+concurrent test JVM cannot pick up the slot mid-restart and misclassify
+it as dead.
 
 ## Programmatic use
 

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/AsAdmin.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/AsAdmin.java
@@ -17,9 +17,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -47,9 +49,21 @@ final class AsAdmin {
     /**
      * Run {@code asadmin <command> <args...>}. Output is collected and logged
      * at the level corresponding to the exit code; {@link AsAdminException}
-     * is thrown with the captured output on non-zero.
+     * is thrown with the captured output on non-zero. Waits unbounded for
+     * the process to exit — use {@link #run(Duration, String, String...)}
+     * if the caller can't tolerate a wedged asadmin.
      */
     void run(String command, String... args) throws AsAdminException {
+        run(null, command, args);
+    }
+
+    /**
+     * Like {@link #run(String, String...)} but bounded: if the asadmin process
+     * does not exit within {@code timeout}, it is force-killed and an
+     * {@link AsAdminException} is thrown. A {@code null} timeout means wait
+     * unbounded.
+     */
+    void run(Duration timeout, String command, String... args) throws AsAdminException {
         Path asadmin = asadminScript();
         List<String> cmd = new ArrayList<>();
         cmd.add(asadmin.toString());
@@ -74,7 +88,16 @@ final class AsAdmin {
             try (InputStream in = process.getInputStream()) {
                 in.transferTo(buf);
             }
-            exit = process.waitFor();
+            if (timeout == null) {
+                exit = process.waitFor();
+            } else if (!process.waitFor(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+                process.destroyForcibly();
+                throw new AsAdminException(
+                        "asadmin " + command + " timed out after " + timeout + "; output so far:\n"
+                        + buf.toString(StandardCharsets.UTF_8));
+            } else {
+                exit = process.exitValue();
+            }
         } catch (IOException | InterruptedException e) {
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolConfiguration.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolConfiguration.java
@@ -26,6 +26,15 @@ import ee.omnifish.arquillian.container.glassfish.CommonGlassFishConfiguration;
  *       match what the build passed to {@code mvn glassfish-pool:up}.</li>
  *   <li>{@code leaseTimeoutSeconds} — how long to wait for an idle slot
  *       before failing the test JVM.</li>
+ *   <li>{@code restartOnRelease} — when {@code true}, the GlassFish domain
+ *       backing the leased slot is restarted (via {@code asadmin restart-domain})
+ *       on container stop, before the slot lock is released. Use this when
+ *       tests leak JVM-scoped state (datasource pools, classloader pins,
+ *       ThreadLocals, EclipseLink session caches) that undeploy alone does
+ *       not clear. Trades suite duration for inter-test isolation — defaults
+ *       to {@code false}. Strongly recommended to also forward
+ *       {@code gf.pool.source} to the test JVM when enabled, so the lease
+ *       loop can re-provision a slot whose restart fails.</li>
  * </ul>
  *
  * <p>{@code httpPort}/{@code httpsPort}/{@code glassFishHome} are populated
@@ -45,6 +54,7 @@ public class GlassFishPoolConfiguration extends CommonGlassFishConfiguration {
     private String poolDir = System.getProperty(PoolConfig.SYS_POOL_DIR);
     private long leaseTimeoutSeconds = Long.parseLong(
             System.getProperty("gf.pool.leaseTimeoutSeconds", String.valueOf(DEFAULT_LEASE_TIMEOUT_SECONDS)));
+    private boolean restartOnRelease = Boolean.getBoolean("gf.pool.restartOnRelease");
 
     private int httpPort = Integer.parseInt(System.getProperty("glassfish.httpPort", "8080"));
     private int httpsPort = Integer.parseInt(System.getProperty("glassfish.httpsPort", "8181"));
@@ -64,6 +74,14 @@ public class GlassFishPoolConfiguration extends CommonGlassFishConfiguration {
 
     public void setLeaseTimeoutSeconds(long leaseTimeoutSeconds) {
         this.leaseTimeoutSeconds = leaseTimeoutSeconds;
+    }
+
+    public boolean isRestartOnRelease() {
+        return restartOnRelease;
+    }
+
+    public void setRestartOnRelease(boolean restartOnRelease) {
+        this.restartOnRelease = restartOnRelease;
     }
 
     public int getHttpPort() {

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolDeployableContainer.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolDeployableContainer.java
@@ -13,6 +13,7 @@ package ee.omnifish.arquillian.container.glassfish.pool;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -52,6 +53,8 @@ import ee.omnifish.arquillian.container.glassfish.CommonGlassFishManager;
 public class GlassFishPoolDeployableContainer implements DeployableContainer<GlassFishPoolConfiguration> {
 
     private static final Logger LOG = Logger.getLogger(GlassFishPoolDeployableContainer.class.getName());
+
+    private static final Duration RESTART_TIMEOUT = Duration.ofSeconds(90);
 
     private GlassFishPoolConfiguration configuration;
     private CommonGlassFishManager<GlassFishPoolConfiguration> manager;
@@ -118,6 +121,12 @@ public class GlassFishPoolDeployableContainer implements DeployableContainer<Gla
         if (lease == null) {
             return;
         }
+        // Restart while the slot lock is still held: a free lock plus a port
+        // momentarily down would let a concurrent leaser classify the slot as
+        // dead and recycle it (wiping the GF install we're restarting).
+        if (configuration.isRestartOnRelease()) {
+            restartLeasedDomain();
+        }
         try {
             lease.close();
         } catch (RuntimeException e) {
@@ -125,6 +134,24 @@ public class GlassFishPoolDeployableContainer implements DeployableContainer<Gla
         } finally {
             lease = null;
             manager = null;
+        }
+    }
+
+    private void restartLeasedDomain() {
+        SlotPorts ports = lease.ports();
+        try {
+            new AsAdmin(Paths.get(ports.glassFishHome())).run(RESTART_TIMEOUT, "restart-domain", "domain1");
+            LOG.info("Restarted GlassFish on slot " + lease.slotIndex()
+                    + " (adminPort=" + ports.adminPort() + ")");
+        } catch (RuntimeException e) {
+            // Log+continue: next leaser's port-health probe will skip the slot
+            // and tryGrow's claimRecyclableSlot will re-provision it from
+            // gf.pool.source (if forwarded). Bounded timeout above guarantees
+            // we never wedge the suite on a hung asadmin.
+            LOG.log(Level.WARNING,
+                    "restart-domain failed on slot " + lease.slotIndex()
+                    + "; releasing lease anyway — slot will be recycled on next lease",
+                    e);
         }
     }
 

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolBootstrap.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolBootstrap.java
@@ -140,6 +140,13 @@ public final class PoolBootstrap {
             if (!java.nio.file.Files.exists(portsFile)) {
                 return false;
             }
+            // A busy slot lock means some leaser owns the slot — either running
+            // tests against a live GF, or mid-restart (restartOnRelease) with
+            // the port briefly closed. Either way the slot is not ours to
+            // reprovision, so skip the port probe to avoid a false negative.
+            if (isLockBusy(config.poolDir(), idx)) {
+                continue;
+            }
             try {
                 SlotPorts ports = SlotPorts.readFrom(portsFile);
                 if (!PoolProvisioner.isPortHealthy(ports.adminPort())) {
@@ -418,7 +425,7 @@ public final class PoolBootstrap {
      * falsely signal an in-flight bootstrap and resurrect a file inside a
      * directory being torn down.
      */
-    private static boolean isLockBusy(Path poolDir, int slot) {
+    static boolean isLockBusy(Path poolDir, int slot) {
         Path lockFile = PoolPaths.lockFile(poolDir, slot);
         if (!Files.exists(lockFile)) {
             return false;
@@ -432,6 +439,10 @@ public final class PoolBootstrap {
             }
             probe.release();
             return false;
+        } catch (java.nio.channels.OverlappingFileLockException e) {
+            // Another channel in this JVM already holds the lock — counts as
+            // busy. Matches SlotLeaser.claimRecyclableSlot's handling.
+            return true;
         } catch (IOException e) {
             return false;
         }

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolProvisioner.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolProvisioner.java
@@ -63,9 +63,13 @@ public final class PoolProvisioner {
         Path portsFile = PoolPaths.portsFile(config.poolDir(), idx);
 
         // Idempotency: skip the heavy work if the slot is already alive and the
-        // ports file is consistent.
-        if (Files.exists(portsFile) && isPortHealthy(adminPort)) {
-            LOG.fine(() -> "Slot " + idx + " already healthy on adminPort=" + adminPort);
+        // ports file is consistent. A busy slot lock also counts — the owning
+        // leaser may be mid-restart (restartOnRelease) with the port briefly
+        // closed; trying to start-domain into that window would fail with
+        // "port already in use" the moment GF re-binds.
+        if (Files.exists(portsFile)
+                && (isPortHealthy(adminPort) || PoolBootstrap.isLockBusy(config.poolDir(), idx))) {
+            LOG.fine(() -> "Slot " + idx + " already provisioned (adminPort=" + adminPort + ")");
             return SlotPorts.readFrom(portsFile);
         }
 

--- a/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/PoolBootstrapTest.java
+++ b/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/PoolBootstrapTest.java
@@ -12,9 +12,12 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.net.InetAddress;
 import java.net.ServerSocket;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -89,6 +92,42 @@ class PoolBootstrapTest {
                     .get(10, TimeUnit.SECONDS);
         } finally {
             exec.shutdown();
+        }
+    }
+
+    /**
+     * Regression for the restartOnRelease vs. concurrent pool-up race:
+     * a slot held by a leaser whose GF is mid-restart presents as
+     * "port not healthy". Without the lock-busy carve-out in
+     * {@link PoolBootstrap#isAlreadyProvisioned}, {@code up} would see the
+     * unhealthy port and try to reprovision the slot under the live
+     * leaser, then race-lose against the GF re-binding adminPort.
+     *
+     * <p>Hold the slot's lock file, point ports.properties at a port nothing
+     * listens on (simulating mid-restart), and assert {@code up} fast-exits
+     * — proven by {@code source=null}: provisioning would NPE on the missing
+     * source.
+     */
+    @Test
+    void upTreatsLockBusySlotAsHealthy(@TempDir Path tmp) throws Exception {
+        Files.createDirectories(PoolPaths.slotDir(tmp, 1));
+        // Reserve an unused port and immediately close it so the slot's
+        // ports.properties points at a port nothing listens on.
+        int deadPort;
+        try (ServerSocket probe = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+            deadPort = probe.getLocalPort();
+        }
+        new SlotPorts(deadPort, deadPort + 1, deadPort + 2, "/fake")
+                .writeTo(PoolPaths.portsFile(tmp, 1));
+
+        Path lockPath = PoolPaths.lockFile(tmp, 1);
+        try (FileChannel ch = FileChannel.open(lockPath,
+                StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE);
+             FileLock held = ch.lock()) {
+            assertThat(held.isValid(), equalTo(true));
+            PoolConfig config = new PoolConfig(tmp, /*source*/null, 1,
+                    PoolConfig.DEFAULT_ADMIN_BASE, PoolConfig.DEFAULT_PORT_STRIDE);
+            PoolBootstrap.up(config); // must fast-exit; provisioning would fail on null source
         }
     }
 


### PR DESCRIPTION
Opt-in (default false). When enabled, the pool container runs asadmin restart-domain against the leased slot's GF install before releasing the file lock, so the next test JVM that picks up the slot gets a fresh GlassFish process. Targets tests that leak JVM-scoped state (datasource pools, classloader pins, ThreadLocals, EclipseLink session caches) that undeploy alone doesn't clear.

Restart is bounded by a 90s timeout so a wedged asadmin can't freeze the suite; AsAdmin grew a (Duration, ...) overload to support this without changing existing call sites. On failure the lease releases anyway and the dead slot is recycled by the next leaser's tryGrow path (requires gf.pool.source to be forwarded, noted in the README).

Configurable at three layers: build-wide via -Dgf.pool.restartOnRelease, per-module via the Maven property when the parent forwards it through failsafe systemPropertyVariables, or per-arquillian.xml via the container <property>.