### PR TITLE
Skip self-held slot in tryAcquire instead of crashing on overlap

### DIFF
--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/SlotLeaser.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/SlotLeaser.java
@@ -138,7 +138,16 @@ public final class SlotLeaser {
                 StandardOpenOption.WRITE);
         FileLock lock = null;
         try {
-            lock = channel.tryLock();
+            try {
+                lock = channel.tryLock();
+            } catch (OverlappingFileLockException e) {
+                // Another channel in THIS JVM already holds the slot lock (e.g.
+                // a lease this JVM hasn't released yet). A foreign JVM would
+                // yield tryLock() == null; only our own process throws. Treat
+                // as busy and skip — mirrors claimRecyclableSlot().
+                channel.close();
+                return null;
+            }
             if (lock == null) {
                 channel.close();
                 return null;

--- a/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/SlotLeaserTest.java
+++ b/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/SlotLeaserTest.java
@@ -235,6 +235,42 @@ class SlotLeaserTest {
         assertThat(violation.get(), nullValue());
     }
 
+    /**
+     * Regression: a second lease in the SAME JVM must skip a slot this JVM
+     * already holds rather than crash. Re-locking a file already locked by
+     * another channel in the same process throws
+     * {@link java.nio.channels.OverlappingFileLockException} (a foreign JVM
+     * would see {@code tryLock() == null} instead), so {@code tryAcquire} must
+     * treat that as "busy, skip" exactly like the recycle path does. Here the
+     * held slot is forced to sort first in the scan so it is re-encountered;
+     * the leaser must fall through to the other ready slot.
+     */
+    @Test
+    void scanSkipsSlotThisJvmAlreadyHoldsInsteadOfThrowing(@TempDir Path tmp) throws Exception {
+        seedSlot(tmp, 1, openFake());
+        seedSlot(tmp, 2, openFake());
+        SlotLeaser leaser = leaserFor(tmp);
+
+        try (SlotLease first = leaser.lease()) {
+            int held = first.slotIndex();
+            int other = held == 1 ? 2 : 1;
+            // Force the held slot to sort first (oldest mtime) so the next
+            // scan re-encounters the lock this JVM already owns.
+            Path otherLock = PoolPaths.lockFile(tmp, other);
+            if (!Files.exists(otherLock)) {
+                Files.createFile(otherLock);
+            }
+            Files.setLastModifiedTime(PoolPaths.lockFile(tmp, held),
+                    java.nio.file.attribute.FileTime.fromMillis(1000));
+            Files.setLastModifiedTime(otherLock,
+                    java.nio.file.attribute.FileTime.fromMillis(2000));
+
+            try (SlotLease second = leaser.lease()) {
+                assertThat(second.slotIndex(), equalTo(other));
+            }
+        }
+    }
+
     @Test
     void releasingLeaseLetsNextLeaserAcquire(@TempDir Path tmp) throws Exception {
         int alive = openFake();


### PR DESCRIPTION
## Problem

`SlotLeaser.tryAcquire` let `OverlappingFileLockException` propagate out of `lease()`, aborting container start. That exception is thrown *only* when another `FileChannel` in the **same JVM** already holds the slot lock (a foreign JVM yields `tryLock() == null`) — it means "this slot is already ours, skip it", not a fault.

Surfaced on the jakartaee/servlet TCK (`AsyncContextTests`):

```
java.nio.channels.OverlappingFileLockException
    at java.base/...FileChannel.tryLock(FileChannel.java:1360)
    at ...SlotLeaser.tryAcquire(SlotLeaser.java:141)
    at ...SlotLeaser.scanAndTryAcquire(SlotLeaser.java:122)
    at ...SlotLeaser.lease(SlotLeaser.java:83)
    at ...GlassFishPoolDeployableContainer.start(...:98)
```

## Fix

Wrap the `tryLock()` in `tryAcquire` to catch `OverlappingFileLockException`, close the channel and return `null` so the scan continues to the next candidate — making it symmetric with `claimRecyclableSlot`, which already handled this. `IOException` from `tryLock` keeps propagating (a real I/O fault worth surfacing).

## Why it never showed in 100+ Faces TCK runs

Earlier framing (parallel test execution) was wrong — corrected here.

`OverlappingFileLockException` is **intra-JVM by definition**: the JDK throws it only when two `FileChannel`s *in the same JVM* attempt overlapping locks on one file. Across JVMs `tryLock()` just returns `null` — that's the whole basis of the pool design. So concurrent forks can't produce this stack; it always means two leases held at once *inside one JVM*.

**Faces TCK** registers a single pool container, so each test JVM leases exactly one slot. No overlap window can open.

**Servlet TCK** (`glassfish-runner/servlet-tck/servlet-tck-run/arquillian.xml`) registers a default **group of two containers**:

```xml
<group qualifier="glassfish-servers" default="true">
    <container qualifier="http"  default="true"> ... </container>
    <container qualifier="https"> ... </container>
</group>
```

Both resolve to the same pool adapter (the only `DeployableContainer` on the classpath). Arquillian starts **every** member of a default group, so one JVM starts `http` **and** `https` → two `lease()` calls held simultaneously. With `gf.pool.size=1` both target slot 1; the second re-finds the slot the first already locked, in the same JVM → `OverlappingFileLockException`. Single-threaded, single module, no parallelism — exactly as the run shows.

With this fix the second container skips the self-held slot; since `gf.pool.source` is forwarded, the leaser then **grows** the pool to a second slot (`http`→slot 1, `https`→slot 2) instead of crashing — the same growth path the runner already relies on for `-TN > pool.size`.

So it's not iteration count and not concurrency — it's a two-container group needing two slots from a size-1 pool.

## Test

`SlotLeaserTest#scanSkipsSlotThisJvmAlreadyHoldsInsteadOfThrowing` reproduces the exact stack (red before the fix), then asserts the second same-JVM lease skips the held slot and acquires the other. Full `SlotLeaserTest` green (9/9), and the full Faces TCK is green with this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
