### PR TITLE
Run postBootCommands in the pool container

### DIFF
--- a/glassfish-common/src/main/java/ee/omnifish/arquillian/container/glassfish/AdminCommandExecutor.java
+++ b/glassfish-common/src/main/java/ee/omnifish/arquillian/container/glassfish/AdminCommandExecutor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish;
+
+import java.util.List;
+
+/**
+ * Executes a single GlassFish admin command against a running DAS. Each
+ * container module supplies its own implementation — managed via an asadmin
+ * subprocess, embedded via the in-process {@code CommandRunner}, pool via
+ * asadmin targeting the leased slot's admin port — so {@link PostBootCommands}
+ * can own the shared parse-and-loop without knowing how a command is run.
+ */
+@FunctionalInterface
+public interface AdminCommandExecutor {
+
+    /**
+     * The first token is not necessarily the subcommand: a post-boot line may
+     * lead with an asadmin utility option such as {@code --passwordfile <file>}.
+     * Implementations therefore append {@code command} and {@code arguments}
+     * verbatim, in order, after asadmin's own options — asadmin accepts utility
+     * options in any order ahead of the subcommand.
+     *
+     * @param command the first token of the command line
+     * @param arguments the remaining tokens, in order
+     * @throws Exception if the command fails; {@link PostBootCommands} decides
+     *         whether to abort or warn-and-continue
+     */
+    void run(String command, List<String> arguments) throws Exception;
+}

--- a/glassfish-common/src/main/java/ee/omnifish/arquillian/container/glassfish/PostBootCommands.java
+++ b/glassfish-common/src/main/java/ee/omnifish/arquillian/container/glassfish/PostBootCommands.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish;
+
+import java.lang.System.Logger;
+import java.util.List;
+
+import static java.lang.System.Logger.Level.WARNING;
+import static java.util.Arrays.copyOfRange;
+
+/**
+ * Runs the {@code glassfish.postBootCommands} list against a started GlassFish
+ * via a container-supplied {@link AdminCommandExecutor}. Centralises the split
+ * and the warn-and-continue policy so each container module only provides the
+ * "how to run one command" half.
+ */
+public final class PostBootCommands {
+
+    private static final Logger LOG = System.getLogger(PostBootCommands.class.getName());
+
+    private PostBootCommands() {
+    }
+
+    /**
+     * Run each post-boot command line through {@code executor}, warning and
+     * continuing on failure. Warn-and-continue is intentional: post-boot
+     * commands are typically idempotent setup (e.g. {@code create-file-user})
+     * that fails benignly when re-run against an already-configured server,
+     * which is the normal case for a recycled pool slot.
+     */
+    public static void execute(List<String> commandLines, AdminCommandExecutor executor) {
+        for (String commandLine : commandLines) {
+            String[] parts = commandLine.trim().split("\\s+");
+            String command = parts[0];
+            List<String> arguments = parts.length > 1
+                    ? List.of(copyOfRange(parts, 1, parts.length))
+                    : List.of();
+            try {
+                executor.run(command, arguments);
+            } catch (Exception e) {
+                LOG.log(WARNING, "Post boot command failed: " + commandLine, e);
+            }
+        }
+    }
+}

--- a/glassfish-common/src/test/java/ee/omnifish/arquillian/container/glassfish/PostBootCommandsTest.java
+++ b/glassfish-common/src/test/java/ee/omnifish/arquillian/container/glassfish/PostBootCommandsTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ */
+package ee.omnifish.arquillian.container.glassfish;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+class PostBootCommandsTest {
+
+    @Test
+    void splitsCommandFromArguments() {
+        List<String[]> captured = new ArrayList<>();
+        PostBootCommands.execute(
+                List.of("--passwordfile /tmp/javajoe.pass create-file-user --groups Manager:Employee javajoe"),
+                (command, args) -> captured.add(prepend(command, args)));
+
+        assertEquals(1, captured.size());
+        assertArrayEquals(
+                new String[] { "--passwordfile", "/tmp/javajoe.pass", "create-file-user", "--groups", "Manager:Employee", "javajoe" },
+                captured.get(0));
+    }
+
+    @Test
+    void collapsesRepeatedWhitespace() {
+        List<String[]> captured = new ArrayList<>();
+        PostBootCommands.execute(List.of("  create-file-user   --groups  Employee  bob  "),
+                (command, args) -> captured.add(prepend(command, args)));
+
+        assertArrayEquals(new String[] { "create-file-user", "--groups", "Employee", "bob" }, captured.get(0));
+    }
+
+    @Test
+    void passesCommandWithoutArguments() {
+        List<String[]> captured = new ArrayList<>();
+        PostBootCommands.execute(List.of("list-file-users"),
+                (command, args) -> captured.add(prepend(command, args)));
+
+        assertArrayEquals(new String[] { "list-file-users" }, captured.get(0));
+    }
+
+    @Test
+    void warnsAndContinuesWhenACommandFails() {
+        List<String> run = new ArrayList<>();
+        PostBootCommands.execute(List.of("first", "boom", "third"), (command, args) -> {
+            run.add(command);
+            if ("boom".equals(command)) {
+                throw new IllegalStateException("user already exists");
+            }
+        });
+
+        assertEquals(List.of("first", "boom", "third"), run);
+    }
+
+    @Test
+    void emptyListRunsNothing() {
+        PostBootCommands.execute(List.of(), (command, args) -> {
+            throw new AssertionError("should not be called");
+        });
+    }
+
+    private static String[] prepend(String command, List<String> args) {
+        List<String> all = new ArrayList<>();
+        all.add(command);
+        all.addAll(args);
+        return all.toArray(String[]::new);
+    }
+}

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/AsAdmin.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/AsAdmin.java
@@ -41,9 +41,22 @@ final class AsAdmin {
             : "java";
 
     private final Path glassFishHome;
+    private final Integer adminPort;
 
     AsAdmin(Path glassFishHome) {
+        this(glassFishHome, null);
+    }
+
+    /**
+     * @param adminPort DAS admin port to target via the {@code --port} program
+     *        option, for subcommands that connect to a running DAS (e.g.
+     *        {@code create-file-user}) instead of operating on a local domain
+     *        directory. A {@code null} port omits {@code --port}, letting
+     *        asadmin default to 4848 or resolve it from the domain operand.
+     */
+    AsAdmin(Path glassFishHome, Integer adminPort) {
         this.glassFishHome = glassFishHome;
+        this.adminPort = adminPort;
     }
 
     /**
@@ -68,6 +81,10 @@ final class AsAdmin {
         List<String> cmd = new ArrayList<>();
         cmd.add(asadmin.toString());
         cmd.add("--terse");
+        if (adminPort != null) {
+            cmd.add("--port");
+            cmd.add(adminPort.toString());
+        }
         cmd.add(command);
         cmd.addAll(Arrays.asList(args));
 

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolConfiguration.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolConfiguration.java
@@ -110,6 +110,10 @@ public class GlassFishPoolConfiguration extends CommonGlassFishConfiguration {
 
     @Override
     public void validate() throws ConfigurationException {
+        // Parses the inherited postBootCommands/systemProperties into their
+        // lists; without this the pool would silently ignore both.
+        super.validate();
+
         if (poolDir == null || poolDir.isEmpty()) {
             throw new ConfigurationException(
                     "poolDir is required (set <property name=\"poolDir\"> in arquillian.xml or "

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolDeployableContainer.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolDeployableContainer.java
@@ -26,6 +26,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptor;
 
 import ee.omnifish.arquillian.container.glassfish.CommonGlassFishManager;
+import ee.omnifish.arquillian.container.glassfish.PostBootCommands;
 
 /**
  * Test-JVM-side container: leases a pre-started slot at {@link #setup} time,
@@ -55,6 +56,7 @@ public class GlassFishPoolDeployableContainer implements DeployableContainer<Gla
     private static final Logger LOG = Logger.getLogger(GlassFishPoolDeployableContainer.class.getName());
 
     private static final Duration RESTART_TIMEOUT = Duration.ofSeconds(90);
+    private static final Duration POSTBOOT_TIMEOUT = Duration.ofSeconds(60);
 
     private GlassFishPoolConfiguration configuration;
     private CommonGlassFishManager<GlassFishPoolConfiguration> manager;
@@ -114,6 +116,17 @@ public class GlassFishPoolDeployableContainer implements DeployableContainer<Gla
 
         manager = new CommonGlassFishManager<>(configuration);
         manager.start();
+
+        runPostBootCommands(ports);
+    }
+
+    private void runPostBootCommands(SlotPorts ports) {
+        // --port targets the leased slot's DAS: post-boot subcommands like
+        // create-file-user connect to a running DAS, which sits on a per-slot
+        // offset port rather than the default 4848.
+        AsAdmin asadmin = new AsAdmin(Paths.get(ports.glassFishHome()), ports.adminPort());
+        PostBootCommands.execute(configuration.getPostBootCommandList(),
+                (command, args) -> asadmin.run(POSTBOOT_TIMEOUT, command, args.toArray(String[]::new)));
     }
 
     @Override


### PR DESCRIPTION
## Problem

The pool container silently ignored `glassfish.postBootCommands`. The config field is inherited from `CommonGlassFishConfiguration`, but only **managed** and **embedded** executed the parsed list — the pool never ran it. On top of that, `GlassFishPoolConfiguration.validate()` overrode the common one **without calling `super.validate()`**, so the list was never even parsed. `systemProperties` suffered the same fate.

The security TCK uses post-boot commands to create native file-users against a leased slot:

```xml
<glassfish.postBootCommands>
    --passwordfile ${project.basedir}/javajoe.pass create-file-user --groups Manager:Employee javajoe
    --passwordfile ${project.basedir}/j2ee.pass create-file-user --groups Administrator:Employee j2ee
</glassfish.postBootCommands>
```

Under the pool container these were dropped, so the authentication tests could not pass.

## Root cause

Two layers:

1. **No shared consumer.** Config lives in common (inherited by all three containers) but execution was copy-pasted only into managed (`GlassFishServerControl`) and embedded (`GlassFishContainer`). A new container author inherits the field for free and silently misses the behavior.
2. **Missing `super.validate()`.** The pool's `validate()` override replaced the common parsing entirely, so `postBootCommandList` (and `systemPropertyList`) stayed empty.

## Change

- New `AdminCommandExecutor` functional interface + `PostBootCommands` helper in **glassfish-common** that own the split and the warn-and-continue policy, decoupled from *how* a command is run. Warn-and-continue is intentional: `create-file-user` fails benignly on a recycled slot where the user already exists.
- **AsAdmin** gains optional `--port` support so post-boot subcommands (which connect to a running DAS) target the leased slot's admin port rather than the default 4848.
- Pool `validate()` now calls `super.validate()`, restoring parsing of both `postBootCommands` and `systemProperties`.
- Pool `start()` runs the commands via `AsAdmin` against the leased slot, after `manager.start()` confirms the DAS is reachable.

Scoped to the pool. **managed** and **embedded** keep their own loops for now; migrating them onto `PostBootCommands` is a pure no-behavior-change follow-up.

## Tests

New `PostBootCommandsTest` covers split, whitespace collapse, no-arg commands, warn-and-continue, and empty list. Full clean build green: glassfish-common 20 tests, glassfish-pool 27 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
