### PR TITLE
Let grouped pool containers share one slot (one GlassFish)

### DIFF
--- a/glassfish-pool/README.md
+++ b/glassfish-pool/README.md
@@ -324,6 +324,33 @@ switch on, the group's qualifier is inferred as each member's `slotGroup`. The
 | Sharing without the global switch, or across *standalone* (non-group) containers | matching `slotGroup` property on each |
 | Distinct slots for specific members of a shared group | a **distinct** `slotGroup` value per member (overrides inference) |
 
+Setting `slotGroup` by hand covers what inference can't — e.g. two
+**standalone** containers (no `<group>`, so nothing to infer from) that should
+still land on one GlassFish. Give them the same value:
+
+```xml
+<container qualifier="http" default="true">
+    <configuration>
+        <property name="poolDir">${gf.pool.dir}</property>
+        <property name="slotGroup">my-server</property>
+        <property name="httpsPortAsDefault">false</property>
+    </configuration>
+</container>
+<container qualifier="https">
+    <configuration>
+        <property name="poolDir">${gf.pool.dir}</property>
+        <property name="slotGroup">my-server</property>
+        <property name="httpsPortAsDefault">true</property>
+    </configuration>
+</container>
+```
+
+The value is just a token — any string works, as long as it **matches** across
+the containers that should share (and they use the same `poolDir`). Conversely,
+to keep two members of a shared `<group>` on their *own* slots, give them
+**different** `slotGroup` values; an explicit value always overrides the
+inferred group qualifier.
+
 Notes:
 
 - All sharing containers must use the **same `poolDir`** — it is part of the

--- a/glassfish-pool/README.md
+++ b/glassfish-pool/README.md
@@ -201,6 +201,7 @@ The pool plugin will then skip staging and clone slots directly from
 | `poolDir`             | String  | `-Dgf.pool.dir`                  | Required. Must match the build's `poolDir`.                                                                 |
 | `leaseTimeoutSeconds` | long    | `600`                            | Lease wait before failing the test JVM.                                                                     |
 | `restartOnRelease`    | boolean | `-Dgf.pool.restartOnRelease`/`false` | Restart GF on the leased slot before releasing the lock. See [Restarting GlassFish between tests](#restarting-glassfish-between-tests). |
+| `slotGroup`           | String  | `-Dgf.pool.slotGroup`/(empty)    | Slot-sharing key; containers sharing it reuse one slot. Inferred from the `<group>` qualifier when `gf.pool.shareGroupSlot=true`. See [Sharing one slot across containers](#sharing-one-slot-across-containers). |
 | `adminUser`           | String  | `admin`                          | Inherited from `CommonGlassFishConfiguration`.                                                              |
 | `adminPassword`       | String  | (empty)                          | Inherited.                                                                                                  |
 | `httpPort`            | int     | overwritten at lease             | Set from the slot's `ports.properties`.                                                                     |
@@ -226,6 +227,7 @@ shell script.
 | `gf.pool.portStride`       | `100`   | Per-slot port spacing. Must be ≥ 10.                   |
 | `gf.pool.systemProperties` | (none)  | Newline-separated `key=value` jvm options (see below). |
 | `gf.pool.restartOnRelease` | `false` | Seeds `restartOnRelease` for every test JVM the build forks. |
+| `gf.pool.shareGroupSlot`   | `false` | When `true`, members of a `<group>` share one slot (http+https idiom). Default keeps a slot per member. |
 
 Slot N's admin port = `adminBase + (N-1) * portStride`; HTTP/HTTPS land at
 `+1` and `+2`. The other GlassFish ports (JMX, IIOP, …) are placed within the
@@ -276,6 +278,61 @@ deadlock. To enable, add to `failsafe`'s `<systemPropertyVariables>`:
 Without `gf.pool.source` the leaser still works against the existing pool —
 it just blocks for an idle slot instead of growing one. That's the right
 default when `forkCount` ≤ `poolSize`.
+
+## Sharing one slot across containers
+
+Each Arquillian container leases its **own** slot — its own GlassFish, its own
+ports, its own lock. That's the right default even for a `<group>`: a group
+generally means several servers a test drives together (clustering/failover),
+which want distinct instances.
+
+The exception is the `http`+`https` idiom, where a group's members are really
+*one* server addressed two ways (a slot already publishes both ports). For that
+case, enable sharing with **`-Dgf.pool.shareGroupSlot=true`**: the members of a
+`<group>` then share a single leased slot, so a size-1 pool suffices.
+
+```xml
+<group qualifier="glassfish-servers" default="true">
+    <container qualifier="http" default="true">
+        <configuration>
+            <property name="httpsPortAsDefault">false</property>
+        </configuration>
+    </container>
+    <container qualifier="https">
+        <configuration>
+            <property name="httpsPortAsDefault">true</property>
+        </configuration>
+    </container>
+</group>
+```
+
+With `-Dgf.pool.shareGroupSlot=true` and that arquillian.xml, both members
+lease one slot per test JVM: the first leases it, the rest attach, and the slot
+is released only when the last one stops. One GlassFish, many container views —
+the managed container's behavior on a size-1 pool. Each container still applies
+its own `httpsPortAsDefault`, so `http` publishes the http port and `https` the
+https port of the same instance.
+
+Under the hood this is slot sharing keyed by `(slotGroup, poolDir)`; with the
+switch on, the group's qualifier is inferred as each member's `slotGroup`. The
+`slotGroup` property gives finer control:
+
+| You want… | Set |
+| --------- | --- |
+| Group members = **distinct** GlassFish instances (default) | nothing — and `pool.size ≥` group size (or forward `gf.pool.source`) |
+| Group members = one server (http+https) | `-Dgf.pool.shareGroupSlot=true` |
+| Sharing without the global switch, or across *standalone* (non-group) containers | matching `slotGroup` property on each |
+| Distinct slots for specific members of a shared group | a **distinct** `slotGroup` value per member (overrides inference) |
+
+Notes:
+
+- All sharing containers must use the **same `poolDir`** — it is part of the
+  share key.
+- Deployments across the sharing containers must have **distinct names**; they
+  all deploy to the same DAS.
+- `restartOnRelease` (if set) fires once, when the last sharer releases. Keep
+  it the same on every member of a group — the finalizing container is whichever
+  stops last, so mixed settings make the restart non-deterministic.
 
 ## Restarting GlassFish between tests (optional)
 

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolConfiguration.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolConfiguration.java
@@ -38,11 +38,15 @@ import ee.omnifish.arquillian.container.glassfish.CommonGlassFishConfiguration;
  *   <li>{@code slotGroup} — opt-in slot sharing. Containers in the same JVM
  *       (same {@code poolDir}) that declare the same non-empty {@code slotGroup}
  *       share ONE leased slot — one physical GlassFish addressed by several
- *       container qualifiers. Use it for an arquillian.xml {@code <group>} such
- *       as {@code http}+{@code https}, where both members are the same server
- *       (a slot already exposes both ports); otherwise each container would
- *       lease its own slot and an N-container group would need {@code pool.size}
- *       ≥ N. Empty (default) keeps the one-container-one-slot behavior.</li>
+ *       container qualifiers. Fits an arquillian.xml {@code <group>} such as
+ *       {@code http}+{@code https}, where both members are the same server (a
+ *       slot already exposes both ports); otherwise each container leases its
+ *       own slot and an N-container group needs {@code pool.size} ≥ N. Empty
+ *       (default) keeps the one-container-one-slot behavior. For a group you
+ *       usually leave this unset and instead pass {@code gf.pool.shareGroupSlot=true},
+ *       which infers {@code slotGroup} from the {@code <group>} qualifier (see
+ *       {@link GroupSlotInference}); set it explicitly only to share across
+ *       non-grouped containers or to override that inference.</li>
  * </ul>
  *
  * <p>{@code httpPort}/{@code httpsPort}/{@code glassFishHome} are populated

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolConfiguration.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolConfiguration.java
@@ -35,6 +35,14 @@ import ee.omnifish.arquillian.container.glassfish.CommonGlassFishConfiguration;
  *       to {@code false}. Strongly recommended to also forward
  *       {@code gf.pool.source} to the test JVM when enabled, so the lease
  *       loop can re-provision a slot whose restart fails.</li>
+ *   <li>{@code slotGroup} — opt-in slot sharing. Containers in the same JVM
+ *       (same {@code poolDir}) that declare the same non-empty {@code slotGroup}
+ *       share ONE leased slot — one physical GlassFish addressed by several
+ *       container qualifiers. Use it for an arquillian.xml {@code <group>} such
+ *       as {@code http}+{@code https}, where both members are the same server
+ *       (a slot already exposes both ports); otherwise each container would
+ *       lease its own slot and an N-container group would need {@code pool.size}
+ *       ≥ N. Empty (default) keeps the one-container-one-slot behavior.</li>
  * </ul>
  *
  * <p>{@code httpPort}/{@code httpsPort}/{@code glassFishHome} are populated
@@ -54,7 +62,10 @@ public class GlassFishPoolConfiguration extends CommonGlassFishConfiguration {
     private String poolDir = System.getProperty(PoolConfig.SYS_POOL_DIR);
     private long leaseTimeoutSeconds = Long.parseLong(
             System.getProperty("gf.pool.leaseTimeoutSeconds", String.valueOf(DEFAULT_LEASE_TIMEOUT_SECONDS)));
+    static final String SYS_SLOT_GROUP = "gf.pool.slotGroup";
+
     private boolean restartOnRelease = Boolean.getBoolean("gf.pool.restartOnRelease");
+    private String slotGroup = System.getProperty(SYS_SLOT_GROUP, "");
 
     private int httpPort = Integer.parseInt(System.getProperty("glassfish.httpPort", "8080"));
     private int httpsPort = Integer.parseInt(System.getProperty("glassfish.httpsPort", "8181"));
@@ -82,6 +93,14 @@ public class GlassFishPoolConfiguration extends CommonGlassFishConfiguration {
 
     public void setRestartOnRelease(boolean restartOnRelease) {
         this.restartOnRelease = restartOnRelease;
+    }
+
+    public String getSlotGroup() {
+        return slotGroup;
+    }
+
+    public void setSlotGroup(String slotGroup) {
+        this.slotGroup = slotGroup;
     }
 
     public int getHttpPort() {

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolDeployableContainer.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolDeployableContainer.java
@@ -58,7 +58,7 @@ public class GlassFishPoolDeployableContainer implements DeployableContainer<Gla
 
     private GlassFishPoolConfiguration configuration;
     private CommonGlassFishManager<GlassFishPoolConfiguration> manager;
-    private SlotLease lease;
+    private LeaseHandle handle;
 
     @Override
     public Class<GlassFishPoolConfiguration> getConfigurationClass() {
@@ -94,50 +94,79 @@ public class GlassFishPoolDeployableContainer implements DeployableContainer<Gla
                 Integer.getInteger(PoolConfig.SYS_ADMIN_BASE, PoolConfig.DEFAULT_ADMIN_BASE),
                 Integer.getInteger(PoolConfig.SYS_PORT_STRIDE, PoolConfig.DEFAULT_PORT_STRIDE));
         SlotLeaser leaser = new SlotLeaser(poolConfig, configuration.getLeaseTimeoutSeconds());
+        String slotGroup = configuration.getSlotGroup();
+        boolean shared = slotGroup != null && !slotGroup.isEmpty();
         try {
-            lease = leaser.lease();
+            // Shared: sibling containers in this JVM (same group + poolDir) reuse
+            // one slot — one GlassFish, many container views. See SharedSlotRegistry.
+            handle = shared
+                    ? SharedSlotRegistry.acquire(new SharedSlotRegistry.Key(slotGroup, poolDir), leaser::lease)
+                    : new LeaseHandle.Direct(leaser.lease());
         } catch (IOException | InterruptedException e) {
             if (e instanceof InterruptedException) {
                 Thread.currentThread().interrupt();
             }
             throw new LifecycleException("Could not lease a pool slot", e);
         }
-        SlotPorts ports = lease.ports();
-        configuration.setAdminHost("localhost");
-        configuration.setAdminPort(ports.adminPort());
-        configuration.setHttpPort(ports.httpPort());
-        configuration.setHttpsPort(ports.httpsPort());
-        configuration.setGlassFishHome(ports.glassFishHome());
+        try {
+            SlotPorts ports = handle.ports();
+            configuration.setAdminHost("localhost");
+            configuration.setAdminPort(ports.adminPort());
+            configuration.setHttpPort(ports.httpPort());
+            configuration.setHttpsPort(ports.httpsPort());
+            configuration.setGlassFishHome(ports.glassFishHome());
 
-        LOG.info("Leased pool slot " + lease.slotIndex()
-                + " (adminPort=" + ports.adminPort() + ")");
+            LOG.info("Leased pool slot " + handle.slotIndex()
+                    + " (adminPort=" + ports.adminPort() + ")"
+                    + (shared ? " [shared group: " + slotGroup + "]" : ""));
 
-        manager = new CommonGlassFishManager<>(configuration);
-        manager.start();
+            manager = new CommonGlassFishManager<>(configuration);
+            manager.start();
+        } catch (RuntimeException | LifecycleException e) {
+            // Arquillian does not call stop() for a container whose start()
+            // threw, so roll back the lease here — otherwise a shared handle
+            // leaks a registry refcount (and the slot lock) for the JVM lifetime.
+            releaseHandle();
+            throw e;
+        }
+    }
+
+    /** Release the held lease and close the slot iff this was its last holder. */
+    private void releaseHandle() {
+        SlotLease toFinalize = handle.release();
+        if (toFinalize != null) {
+            toFinalize.close();
+        }
+        handle = null;
+        manager = null;
     }
 
     @Override
     public void stop() throws LifecycleException {
-        if (lease == null) {
+        if (handle == null) {
             return;
         }
-        // Restart while the slot lock is still held: a free lock plus a port
-        // momentarily down would let a concurrent leaser classify the slot as
-        // dead and recycle it (wiping the GF install we're restarting).
-        if (configuration.isRestartOnRelease()) {
-            restartLeasedDomain();
+        // For a shared slot only the LAST holder finalizes it; earlier holders
+        // get null here and leave the slot up for their siblings.
+        SlotLease toFinalize = handle.release();
+        if (toFinalize != null) {
+            // Restart while the slot lock is still held: a free lock plus a port
+            // momentarily down would let a concurrent leaser classify the slot as
+            // dead and recycle it (wiping the GF install we're restarting).
+            if (configuration.isRestartOnRelease()) {
+                restartLeasedDomain(toFinalize);
+            }
+            try {
+                toFinalize.close();
+            } catch (RuntimeException e) {
+                LOG.log(Level.WARNING, "Releasing slot lease " + toFinalize.slotIndex() + " failed", e);
+            }
         }
-        try {
-            lease.close();
-        } catch (RuntimeException e) {
-            LOG.log(Level.WARNING, "Releasing slot lease " + lease.slotIndex() + " failed", e);
-        } finally {
-            lease = null;
-            manager = null;
-        }
+        handle = null;
+        manager = null;
     }
 
-    private void restartLeasedDomain() {
+    private void restartLeasedDomain(SlotLease lease) {
         SlotPorts ports = lease.ports();
         try {
             new AsAdmin(Paths.get(ports.glassFishHome())).run(RESTART_TIMEOUT, "restart-domain", "domain1");

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolExtension.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GlassFishPoolExtension.java
@@ -15,7 +15,8 @@ import org.jboss.arquillian.core.spi.LoadableExtension;
 
 /**
  * Registers {@link GlassFishPoolDeployableContainer} as the Arquillian
- * {@link DeployableContainer} implementation. Picked up via the
+ * {@link DeployableContainer} implementation, plus {@link GroupSlotInference}
+ * which lets the members of a {@code <group>} share one slot. Picked up via the
  * {@code META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension}
  * descriptor on the classpath.
  */
@@ -24,5 +25,6 @@ public class GlassFishPoolExtension implements LoadableExtension {
     @Override
     public void register(ExtensionBuilder builder) {
         builder.service(DeployableContainer.class, GlassFishPoolDeployableContainer.class);
+        builder.observer(GroupSlotInference.class);
     }
 }

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GroupSlotInference.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/GroupSlotInference.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import java.util.logging.Logger;
+
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.config.descriptor.api.ContainerDef;
+import org.jboss.arquillian.config.descriptor.api.GroupDef;
+import org.jboss.arquillian.container.spi.Container;
+import org.jboss.arquillian.container.spi.event.SetupContainer;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+
+/**
+ * Defaults a grouped pool container's {@code slotGroup} to its Arquillian
+ * {@code <group>} qualifier, so the members of a group (e.g. {@code http} +
+ * {@code https}) share one leased slot — one physical GlassFish — with no
+ * per-container configuration.
+ *
+ * <p>Off by default: an Arquillian {@code <group>} generally means several
+ * servers a test drives together (clustering/failover), which want distinct
+ * instances. Enable with {@code -Dgf.pool.shareGroupSlot=true} when a group is
+ * instead "many views of one server" (the http+https idiom, matching the
+ * managed container's behavior); the members then share a slot, and a size-1
+ * pool suffices. An explicit {@code slotGroup} property (or
+ * {@code -Dgf.pool.slotGroup}) always wins over inference — set it directly to
+ * share without the global switch, or give members distinct values to keep them
+ * apart.
+ *
+ * <p>Mutates the {@link ContainerDef} on {@link SetupContainer} at a precedence
+ * ahead of {@code ContainerLifecycleController}, which only then maps the
+ * {@link ContainerDef} onto the typed config — so the inferred value reaches
+ * {@link GlassFishPoolConfiguration#getSlotGroup()}. Only pool containers are
+ * touched.
+ */
+public class GroupSlotInference {
+
+    private static final Logger LOG = Logger.getLogger(GroupSlotInference.class.getName());
+
+    static final String SHARE_GROUP_SLOT = "gf.pool.shareGroupSlot";
+    static final String SLOT_GROUP_PROPERTY = "slotGroup";
+
+    @Inject
+    private Instance<ArquillianDescriptor> descriptor;
+
+    public void inferSlotGroup(@Observes(precedence = 100) SetupContainer event) {
+        Container<?> container = event.getContainer();
+        if (!(container.getDeployableContainer() instanceof GlassFishPoolDeployableContainer)) {
+            return;
+        }
+        ContainerDef config = container.getContainerConfiguration();
+        String group = inferredSlotGroup(descriptor.get(), container.getName(),
+                config.getContainerProperty(SLOT_GROUP_PROPERTY),
+                System.getProperty(GlassFishPoolConfiguration.SYS_SLOT_GROUP),
+                shareGroupSlotEnabled());
+        if (group != null) {
+            config.property(SLOT_GROUP_PROPERTY, group);
+            LOG.info("Container '" + container.getName() + "' shares slot group '" + group
+                    + "' with its <group> siblings (one GlassFish for the group)");
+        }
+    }
+
+    /**
+     * The {@code slotGroup} to infer for {@code containerName}, or {@code null}
+     * to leave it untouched. Inference is skipped when disabled, or when sharing
+     * is already pinned explicitly (a per-container {@code slotGroup} property or
+     * the {@code -Dgf.pool.slotGroup} global both win), or when the container is
+     * standalone.
+     */
+    static String inferredSlotGroup(ArquillianDescriptor descriptor, String containerName,
+            String explicitProperty, String globalDefault, boolean enabled) {
+        if (!enabled || hasText(explicitProperty) || hasText(globalDefault)) {
+            return null;
+        }
+        return groupNameFor(descriptor, containerName);
+    }
+
+    /**
+     * The qualifier of the group {@code containerName} belongs to, or
+     * {@code null} if it is standalone. A container declared in more than one
+     * group (which Arquillian permits) resolves to the first-declared one.
+     */
+    static String groupNameFor(ArquillianDescriptor descriptor, String containerName) {
+        if (descriptor == null) {
+            return null;
+        }
+        for (GroupDef group : descriptor.getGroups()) {
+            for (ContainerDef member : group.getGroupContainers()) {
+                if (containerName.equals(member.getContainerName())) {
+                    return group.getGroupName();
+                }
+            }
+        }
+        return null;
+    }
+
+    private static boolean shareGroupSlotEnabled() {
+        return Boolean.getBoolean(SHARE_GROUP_SLOT);
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isEmpty();
+    }
+}

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/LeaseHandle.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/LeaseHandle.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+/**
+ * A held slot lease as seen by the container: either a private lease
+ * ({@link Direct}) or one shared with sibling containers in the same JVM
+ * ({@link Shared}, backed by {@link SharedSlotRegistry}). Lets the container's
+ * {@code start()}/{@code stop()} treat both the same way.
+ *
+ * <p>A handle is confined to its owning container, whose lifecycle Arquillian
+ * drives on a single thread — hence the plain (non-volatile) {@code released}
+ * guards need no memory barrier. The shared <em>slot</em> state lives in
+ * {@link SharedSlotRegistry}, which does synchronize.
+ */
+interface LeaseHandle {
+
+    SlotPorts ports();
+
+    int slotIndex();
+
+    /**
+     * Relinquish this holder's claim. Returns the underlying {@link SlotLease}
+     * for the caller to finalize (restart-if-configured, then close) iff this
+     * was the last holder of the slot; otherwise {@code null} (a shared slot
+     * still in use by siblings). Idempotent — a second call returns
+     * {@code null}.
+     */
+    SlotLease release();
+
+    /** Private, single-holder lease — the default (non-shared) path. */
+    final class Direct implements LeaseHandle {
+
+        private final SlotLease lease;
+        private boolean released;
+
+        Direct(SlotLease lease) {
+            this.lease = lease;
+        }
+
+        @Override
+        public SlotPorts ports() {
+            return lease.ports();
+        }
+
+        @Override
+        public int slotIndex() {
+            return lease.slotIndex();
+        }
+
+        @Override
+        public SlotLease release() {
+            if (released) {
+                return null;
+            }
+            released = true;
+            return lease;
+        }
+    }
+
+    /** Shared lease: many holders, one slot. Backed by {@link SharedSlotRegistry}. */
+    final class Shared implements LeaseHandle {
+
+        private final SharedSlotRegistry.Key key;
+        private final SlotLease lease;
+        private boolean released;
+
+        Shared(SharedSlotRegistry.Key key, SlotLease lease) {
+            this.key = key;
+            this.lease = lease;
+        }
+
+        @Override
+        public SlotPorts ports() {
+            return lease.ports();
+        }
+
+        @Override
+        public int slotIndex() {
+            return lease.slotIndex();
+        }
+
+        @Override
+        public SlotLease release() {
+            if (released) {
+                return null;
+            }
+            released = true;
+            return SharedSlotRegistry.release(key);
+        }
+    }
+}

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/SharedSlotRegistry.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/SharedSlotRegistry.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * JVM-wide registry of shared slot leases, keyed by {@code (slotGroup, poolDir)}.
+ * Lets several Arquillian containers in one test JVM — e.g. the {@code http}
+ * and {@code https} members of an arquillian.xml {@code <group>} — share ONE
+ * leased slot (one physical GlassFish) instead of each leasing its own.
+ *
+ * <p>Reference-counted: the first {@link #acquire} leases a real slot, later
+ * ones attach to it, and the last {@link #release} hands the lease back for
+ * finalization. This restores the managed container's "one instance, many
+ * views" semantics — a single slot already exposes both http and https ports
+ * (see {@link SlotPorts}), so each sharing container just publishes its own
+ * default.
+ *
+ * <p>Without sharing, an N-container group on a size-1 pool cannot run: each
+ * container leases independently, so the group needs N slots (or
+ * {@code gf.pool.source} forwarded to grow into them).
+ */
+final class SharedSlotRegistry {
+
+    /** Leases a slot; may block and may throw, hence not a plain {@link java.util.function.Supplier}. */
+    @FunctionalInterface
+    interface LeaseSupplier {
+        SlotLease get() throws IOException, InterruptedException;
+    }
+
+    private static final Object LOCK = new Object();
+    private static final Map<Key, Entry> ENTRIES = new HashMap<>();
+
+    private SharedSlotRegistry() {
+    }
+
+    /**
+     * Attach to the slot shared under {@code key}, leasing one via
+     * {@code supplier} if this is the first caller.
+     *
+     * <p>The lease is taken outside the registry lock so a slow {@code lease()}
+     * (polling/growing) can't stall acquirers of <em>other</em> groups. If two
+     * threads race the <em>same</em> key, the loser closes its redundant lease
+     * and shares the winner's. Note that race needs a pool large enough for the
+     * loser to lease a second slot at all; in Arquillian's normal flow
+     * containers in one JVM start serially on one thread, so it doesn't arise.
+     */
+    static LeaseHandle acquire(Key key, LeaseSupplier supplier) throws IOException, InterruptedException {
+        synchronized (LOCK) {
+            Entry existing = ENTRIES.get(key);
+            if (existing != null) {
+                existing.refCount++;
+                return new LeaseHandle.Shared(key, existing.lease);
+            }
+        }
+        SlotLease leased = supplier.get();
+        synchronized (LOCK) {
+            Entry existing = ENTRIES.get(key);
+            if (existing != null) {
+                existing.refCount++;
+                leased.close(); // lost the race — release the redundant slot
+                return new LeaseHandle.Shared(key, existing.lease);
+            }
+            ENTRIES.put(key, new Entry(leased));
+            return new LeaseHandle.Shared(key, leased);
+        }
+    }
+
+    /**
+     * Drop one holder of {@code key}. Returns the underlying {@link SlotLease}
+     * for the caller to finalize (restart-if-configured, then close) iff this
+     * was the last holder; otherwise {@code null}.
+     */
+    static SlotLease release(Key key) {
+        synchronized (LOCK) {
+            Entry entry = ENTRIES.get(key);
+            if (entry == null) {
+                return null; // already gone — defensive against double release
+            }
+            if (--entry.refCount > 0) {
+                return null;
+            }
+            ENTRIES.remove(key);
+            return entry.lease;
+        }
+    }
+
+    /** Whether no slot is currently shared — used by tests to assert no leaked refcounts. */
+    static boolean isIdle() {
+        synchronized (LOCK) {
+            return ENTRIES.isEmpty();
+        }
+    }
+
+    /** Composite key: same group AND same pool dir share a slot. */
+    static final class Key {
+
+        private final String group;
+        private final Path poolDir;
+
+        Key(String group, Path poolDir) {
+            this.group = Objects.requireNonNull(group, "group");
+            this.poolDir = Objects.requireNonNull(poolDir, "poolDir");
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Key)) {
+                return false;
+            }
+            Key other = (Key) o;
+            return group.equals(other.group) && poolDir.equals(other.poolDir);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(group, poolDir);
+        }
+
+        @Override
+        public String toString() {
+            return "slotGroup=" + group + " @ " + poolDir;
+        }
+    }
+
+    private static final class Entry {
+
+        final SlotLease lease;
+        int refCount = 1;
+
+        Entry(SlotLease lease) {
+            this.lease = lease;
+        }
+    }
+}

--- a/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/GroupSlotInferenceTest.java
+++ b/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/GroupSlotInferenceTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 OmniFish and/or its affiliates. All rights reserved.
+ */
+package ee.omnifish.arquillian.container.glassfish.pool;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
+
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.config.descriptor.api.GroupDef;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the group-qualifier lookup that drives slot-group inference.
+ * The observer wiring (event timing, config mapping) is exercised end-to-end by
+ * the integration test; here we pin the pure container-to-group resolution.
+ */
+class GroupSlotInferenceTest {
+
+    private ArquillianDescriptor httpHttpsGroup() {
+        ArquillianDescriptor descriptor = Descriptors.create(ArquillianDescriptor.class);
+        GroupDef group = descriptor.group("glassfish-servers");
+        group.container("http");
+        group.container("https");
+        return descriptor;
+    }
+
+    @Test
+    void resolvesGroupOfAMember() {
+        ArquillianDescriptor descriptor = httpHttpsGroup();
+        assertThat(GroupSlotInference.groupNameFor(descriptor, "http"), equalTo("glassfish-servers"));
+        assertThat(GroupSlotInference.groupNameFor(descriptor, "https"), equalTo("glassfish-servers"));
+    }
+
+    @Test
+    void returnsNullForStandaloneOrUnknownContainer() {
+        ArquillianDescriptor descriptor = Descriptors.create(ArquillianDescriptor.class);
+        descriptor.container("solo"); // top-level, not in a group
+
+        assertThat(GroupSlotInference.groupNameFor(descriptor, "solo"), nullValue());
+        assertThat(GroupSlotInference.groupNameFor(httpHttpsGroup(), "absent"), nullValue());
+    }
+
+    @Test
+    void nullDescriptorYieldsNoGroup() {
+        assertThat(GroupSlotInference.groupNameFor(null, "http"), nullValue());
+    }
+
+    // --- inferredSlotGroup: precedence rules ---
+
+    @Test
+    void infersGroupQualifierWhenEnabledAndNothingExplicit() {
+        assertThat(
+                GroupSlotInference.inferredSlotGroup(httpHttpsGroup(), "https", null, null, true),
+                equalTo("glassfish-servers"));
+    }
+
+    @Test
+    void doesNotInferWhenDisabled() {
+        assertThat(
+                GroupSlotInference.inferredSlotGroup(httpHttpsGroup(), "https", null, null, false),
+                nullValue());
+    }
+
+    @Test
+    void explicitContainerPropertyWins() {
+        assertThat(
+                GroupSlotInference.inferredSlotGroup(httpHttpsGroup(), "https", "mine", null, true),
+                nullValue());
+    }
+
+    @Test
+    void globalDefaultWins() {
+        assertThat(
+                GroupSlotInference.inferredSlotGroup(httpHttpsGroup(), "https", null, "global", true),
+                nullValue());
+    }
+
+    @Test
+    void standaloneContainerInfersNothing() {
+        ArquillianDescriptor descriptor = Descriptors.create(ArquillianDescriptor.class);
+        descriptor.container("solo");
+        assertThat(
+                GroupSlotInference.inferredSlotGroup(descriptor, "solo", null, null, true),
+                nullValue());
+    }
+}

--- a/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/SlotLeaserTest.java
+++ b/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/SlotLeaserTest.java
@@ -6,8 +6,10 @@ package ee.omnifish.arquillian.container.glassfish.pool;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
@@ -49,6 +51,9 @@ class SlotLeaserTest {
             s.close();
         }
         fakes.clear();
+        // Shared-slot tests must fully release; a leaked refcount would poison
+        // later tests (the registry is JVM-static).
+        assertThat(SharedSlotRegistry.isIdle(), equalTo(true));
     }
 
     @Test
@@ -283,6 +288,105 @@ class SlotLeaserTest {
 
         try (SlotLease second = leaser.lease()) {
             assertThat(second.slotIndex(), equalTo(1));
+        }
+    }
+
+    // --- shared-lease (SharedSlotRegistry / LeaseHandle) ---
+
+    @Test
+    void sharedGroupReusesOneSlotForSiblings(@TempDir Path tmp) throws Exception {
+        int adminPort = openFake();
+        seedSlot(tmp, 1, adminPort);
+        SlotLeaser leaser = leaserFor(tmp);
+        SharedSlotRegistry.Key key = new SharedSlotRegistry.Key("group", tmp);
+
+        // Two siblings attach to the SAME slot — the second does not lease a new
+        // one (it would have to skip the self-held slot and time out otherwise).
+        LeaseHandle first = SharedSlotRegistry.acquire(key, leaser::lease);
+        LeaseHandle second = SharedSlotRegistry.acquire(key, leaser::lease);
+        assertThat(first.slotIndex(), equalTo(1));
+        assertThat(second.slotIndex(), equalTo(1));
+        assertThat(second.ports().adminPort(), equalTo(adminPort));
+
+        // Non-last release keeps the slot up; last release hands the lease back.
+        assertThat(second.release(), nullValue());
+        SlotLease toFinalize = first.release();
+        assertThat(toFinalize, notNullValue());
+        assertThat(first.release(), nullValue()); // idempotent
+        toFinalize.close();
+
+        // Slot is free again — a fresh lease re-acquires it.
+        try (SlotLease reacquired = leaserFor(tmp).lease()) {
+            assertThat(reacquired.slotIndex(), equalTo(1));
+        }
+    }
+
+    @Test
+    void onlyLastOfThreeHoldersFinalizes(@TempDir Path tmp) throws Exception {
+        seedSlot(tmp, 1, openFake());
+        SlotLeaser leaser = leaserFor(tmp);
+        SharedSlotRegistry.Key key = new SharedSlotRegistry.Key("group", tmp);
+
+        LeaseHandle a = SharedSlotRegistry.acquire(key, leaser::lease);
+        LeaseHandle b = SharedSlotRegistry.acquire(key, leaser::lease);
+        LeaseHandle c = SharedSlotRegistry.acquire(key, leaser::lease);
+
+        assertThat(a.release(), nullValue()); // 3 -> 2
+        assertThat(c.release(), nullValue()); // 2 -> 1
+        SlotLease toFinalize = b.release();    // 1 -> 0
+        assertThat(toFinalize, notNullValue());
+        toFinalize.close();
+    }
+
+    @Test
+    void singleHolderReleaseFreesSlotForReLease(@TempDir Path tmp) throws Exception {
+        // Pins the start()-failure rollback contract: releasing a leader that
+        // never gained a sibling must hand back the lease so the slot is reusable.
+        seedSlot(tmp, 1, openFake());
+        SharedSlotRegistry.Key key = new SharedSlotRegistry.Key("group", tmp);
+
+        LeaseHandle only = SharedSlotRegistry.acquire(key, leaserFor(tmp)::lease);
+        SlotLease toFinalize = only.release();
+        assertThat(toFinalize, notNullValue());
+        toFinalize.close();
+
+        try (SlotLease reacquired = leaserFor(tmp).lease()) {
+            assertThat(reacquired.slotIndex(), equalTo(1));
+        }
+    }
+
+    @Test
+    void differentGroupsLeaseDistinctSlots(@TempDir Path tmp) throws Exception {
+        seedSlot(tmp, 1, openFake());
+        seedSlot(tmp, 2, openFake());
+        SlotLeaser leaser = leaserFor(tmp);
+
+        LeaseHandle a = SharedSlotRegistry.acquire(new SharedSlotRegistry.Key("a", tmp), leaser::lease);
+        LeaseHandle b = SharedSlotRegistry.acquire(new SharedSlotRegistry.Key("b", tmp), leaser::lease);
+        try {
+            assertThat(a.slotIndex(), not(equalTo(b.slotIndex())));
+        } finally {
+            finalizeAndClose(a);
+            finalizeAndClose(b);
+        }
+    }
+
+    @Test
+    void directHandleReturnsLeaseOnceThenNull(@TempDir Path tmp) throws Exception {
+        seedSlot(tmp, 1, openFake());
+        SlotLease lease = leaserFor(tmp).lease();
+        LeaseHandle handle = new LeaseHandle.Direct(lease);
+
+        assertThat(handle.slotIndex(), equalTo(1));
+        assertThat(handle.release(), sameInstance(lease));
+        assertThat(handle.release(), nullValue()); // idempotent
+        lease.close();
+    }
+
+    private static void finalizeAndClose(LeaseHandle handle) {
+        SlotLease toFinalize = handle.release();
+        if (toFinalize != null) {
+            toFinalize.close();
         }
     }
 


### PR DESCRIPTION
## Problem

Each Arquillian container leases its **own** pool slot, so an arquillian.xml `<group>` of N containers needs `pool.size ≥ N` — every qualifier becomes a separate GlassFish. That's the right default for the canonical group (several servers a test drives together, e.g. clustering). But the `http`+`https` idiom is a group of **two views of one server**, and on a size-1 pool the second member collided on the slot lock (the `OverlappingFileLockException` fixed in #51 — afterward it merely fails to get a slot).

This is how the **managed** container worked: `http`/`https` shared one fixed server. The pool's per-container leasing broke that.

## Change

Opt-in slot sharing. Containers in one JVM with the same `slotGroup` and `poolDir` share a single leased slot via a reference-counted `SharedSlotRegistry`: the first leases it, siblings attach, the last releases. A `LeaseHandle` (`Direct` vs `Shared`) lets `start()`/`stop()` treat both paths uniformly; `restartOnRelease` fires once, at final release. `start()` rolls the lease back on a post-acquire failure, since Arquillian skips `stop()` when `start()` threw.

`GroupSlotInference` (an `@Observes SetupContainer` observer, precedence ahead of the lifecycle controller) defaults each grouped pool container's `slotGroup` to its `<group>` qualifier — so a group shares with **zero** per-container config. It's **off by default**; enable with `-Dgf.pool.shareGroupSlot=true` for the http+https idiom. An explicit `slotGroup` property (or `-Dgf.pool.slotGroup`) always wins; distinct values force distinct slots.

## Usage (servlet TCK http+https on a size-1 pool)

Forward one property to the test JVM:

```xml
<gf.pool.shareGroupSlot>true</gf.pool.shareGroupSlot>
```

Logs `Container 'https' shares slot group 'glassfish-servers' …`, and one GlassFish serves the whole group.

## Tests

`SharedSlotRegistry`/`LeaseHandle`: sibling reuse, only-last-of-three finalizes, single-holder rollback, distinct groups → distinct slots, idempotent release, plus an `@AfterEach` registry-leak guard. `GroupSlotInference`: group lookup + the inference precedence rules (enabled/disabled, explicit-property-wins, global-default-wins, standalone). Full module green (40 tests). The Arquillian event-timing assumption was verified against arquillian-container-impl 1.10.1. Smoke-tested end-to-end on the jakartaee/platform-tck servlet runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)