### PR TITLE
Support glassfish.debug/glassfish.suspend on the pool container

### DIFF
--- a/glassfish-pool-maven-plugin/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/mojo/AbstractPoolMojo.java
+++ b/glassfish-pool-maven-plugin/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/mojo/AbstractPoolMojo.java
@@ -70,9 +70,25 @@ abstract class AbstractPoolMojo extends AbstractMojo {
     @Parameter(property = "glassfish.systemProperties")
     protected String systemProperties;
 
+    /**
+     * Start each slot's domain in debug mode. Shares the {@code glassfish.debug}
+     * property with the managed container.
+     */
+    @Parameter(property = "glassfish.debug", defaultValue = "false")
+    protected boolean debug;
+
+    /**
+     * Start each slot's domain suspended, waiting for a debugger to attach.
+     * Shares the {@code glassfish.suspend} property with the managed container.
+     * Only valid for a single-slot pool ({@code gf.pool.size=1}) — suspend
+     * blocks the server JVM and all slot clones share one debug port.
+     */
+    @Parameter(property = "glassfish.suspend", defaultValue = "false")
+    protected boolean suspend;
+
     protected PoolConfig poolConfig() {
         Path source = (poolSource == null) ? null : poolSource.toPath();
         return new PoolConfig(poolDir.toPath(), source, poolSize, adminPortBase, portStride,
-                PoolConfig.parseSystemProperties(systemProperties));
+                PoolConfig.parseSystemProperties(systemProperties), debug, suspend);
     }
 }

--- a/glassfish-pool/README.md
+++ b/glassfish-pool/README.md
@@ -228,6 +228,8 @@ shell script.
 | `gf.pool.systemProperties` | (none)  | Newline-separated `key=value` jvm options (see below). |
 | `gf.pool.restartOnRelease` | `false` | Seeds `restartOnRelease` for every test JVM the build forks. |
 | `gf.pool.shareGroupSlot`   | `false` | When `true`, members of a `<group>` share one slot (http+https idiom). Default keeps a slot per member. |
+| `glassfish.debug`          | `false` | Start each slot's domain in debug mode (`start-domain --debug`). Same property name as the managed container. |
+| `glassfish.suspend`        | `false` | Start the domain suspended, waiting for a debugger (`start-domain --suspend`). Requires `gf.pool.size=1` (see below). Same property name as the managed container. |
 
 Slot N's admin port = `adminBase + (N-1) * portStride`; HTTP/HTTPS land at
 `+1` and `+2`. The other GlassFish ports (JMX, IIOP, …) are placed within the
@@ -262,6 +264,18 @@ Each entry becomes a `<jvm-options>-Dkey=value</jvm-options>` child of every
 `<java-config>` in each slot's `domain.xml`, written through the same
 inode-replacing atomic move as port rewrites (so the source install stays
 intact). Override at the command line with `-Dglassfish.systemProperties=…`.
+
+### Debugging a slot
+
+`-Dglassfish.debug` and `-Dglassfish.suspend` pass `--debug` / `--suspend` to
+each slot's `start-domain`, using the same property names as the managed
+container. `--suspend` blocks the server JVM at startup until a debugger
+attaches, so `glassfish-pool:up` will not return until you connect.
+
+Because suspend halts the JVM and every slot clone shares one JDWP debug port,
+it is only valid for a **single-slot pool**. The plugin throws
+`IllegalArgumentException` when `glassfish.suspend` is set with `gf.pool.size`
+> 1 — run a suspended pool with `-T1` (and `gf.pool.size=1`).
 
 ## Growing on demand (optional)
 

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolConfig.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolConfig.java
@@ -54,6 +54,8 @@ public final class PoolConfig {
     private final int adminPortBase;
     private final int portStride;
     private final List<String> systemProperties;
+    private final boolean debug;
+    private final boolean suspend;
 
     public PoolConfig(Path poolDir, Path source, int size, int adminPortBase, int portStride) {
         this(poolDir, source, size, adminPortBase, portStride, List.of());
@@ -61,9 +63,20 @@ public final class PoolConfig {
 
     public PoolConfig(Path poolDir, Path source, int size, int adminPortBase, int portStride,
                       List<String> systemProperties) {
+        this(poolDir, source, size, adminPortBase, portStride, systemProperties, false, false);
+    }
+
+    public PoolConfig(Path poolDir, Path source, int size, int adminPortBase, int portStride,
+                      List<String> systemProperties, boolean debug, boolean suspend) {
         if (portStride < MIN_PORT_STRIDE) {
             throw new IllegalArgumentException(
                     "portStride must be >= " + MIN_PORT_STRIDE + " (got " + portStride + ")");
+        }
+        if (suspend && size > 1) {
+            throw new IllegalArgumentException(
+                    "glassfish.suspend requires a single-slot pool (gf.pool.size=1); got size=" + size
+                    + ". Suspend blocks the server JVM until a debugger attaches and all slot clones "
+                    + "share one debug port — run the suspended pool with -T1.");
         }
         this.poolDir = Objects.requireNonNull(poolDir, "poolDir");
         this.source = source;
@@ -73,6 +86,8 @@ public final class PoolConfig {
         this.systemProperties = (systemProperties == null)
                 ? List.of()
                 : Collections.unmodifiableList(List.copyOf(systemProperties));
+        this.debug = debug;
+        this.suspend = suspend;
     }
 
     public Path poolDir() {
@@ -118,6 +133,25 @@ public final class PoolConfig {
     }
 
     /**
+     * Start each slot's domain in debug mode ({@code start-domain --debug}).
+     * Sourced from the {@code glassfish.debug} property, shared with the
+     * managed container.
+     */
+    public boolean debug() {
+        return debug;
+    }
+
+    /**
+     * Start each slot's domain suspended, waiting for a debugger to attach
+     * ({@code start-domain --suspend}). Sourced from {@code glassfish.suspend},
+     * shared with the managed container. Only valid for a single-slot pool
+     * (enforced in the constructor) — see that guard for the rationale.
+     */
+    public boolean suspend() {
+        return suspend;
+    }
+
+    /**
      * Construct from system properties. Used by {@link PoolBootstrap} so a
      * Maven antrun {@code <java>} invocation can pass everything via
      * {@code <sysproperty>} without a CLI dance.
@@ -129,7 +163,9 @@ public final class PoolConfig {
                 Integer.parseInt(System.getProperty(SYS_SIZE, "1")),
                 Integer.parseInt(System.getProperty(SYS_ADMIN_BASE, String.valueOf(DEFAULT_ADMIN_BASE))),
                 Integer.parseInt(System.getProperty(SYS_PORT_STRIDE, String.valueOf(DEFAULT_PORT_STRIDE))),
-                parseSystemProperties(System.getProperty(SYS_SYSTEM_PROPERTIES)));
+                parseSystemProperties(System.getProperty(SYS_SYSTEM_PROPERTIES)),
+                Boolean.getBoolean("glassfish.debug"),
+                Boolean.getBoolean("glassfish.suspend"));
     }
 
     /**

--- a/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolProvisioner.java
+++ b/glassfish-pool/src/main/java/ee/omnifish/arquillian/container/glassfish/pool/PoolProvisioner.java
@@ -15,7 +15,9 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -93,7 +95,7 @@ public final class PoolProvisioner {
 
         AsAdmin asadmin = new AsAdmin(slotInstall);
         try {
-            asadmin.run("start-domain", "domain1");
+            asadmin.run("start-domain", startDomainArgs());
         } catch (AsAdmin.AsAdminException e) {
             LOG.log(Level.SEVERE, "Slot " + idx + " start-domain failed", e);
             throw new IOException("Slot " + idx + " start-domain failed: " + e.getMessage(), e);
@@ -103,6 +105,23 @@ public final class PoolProvisioner {
         ports.writeTo(portsFile);
         LOG.info("Slot " + idx + " provisioned: adminPort=" + adminPort + ", http=" + httpPort);
         return ports;
+    }
+
+    /**
+     * Build the {@code start-domain} argument list: optional {@code --debug} /
+     * {@code --suspend} (mirroring the managed container) followed by the domain
+     * operand. {@code --suspend} blocks the server JVM until a debugger attaches.
+     */
+    private String[] startDomainArgs() {
+        List<String> args = new ArrayList<>();
+        if (config.debug()) {
+            args.add("--debug");
+        }
+        if (config.suspend()) {
+            args.add("--suspend");
+        }
+        args.add("domain1");
+        return args.toArray(String[]::new);
     }
 
     /** Stop a slot's GlassFish if its admin port is responding. Best-effort; logs failures. */

--- a/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/PoolConfigTest.java
+++ b/glassfish-pool/src/test/java/ee/omnifish/arquillian/container/glassfish/pool/PoolConfigTest.java
@@ -63,4 +63,19 @@ class PoolConfigTest {
                 java.util.List.of("a=b", "c=d"));
         assertThat(c.systemProperties(), contains("a=b", "c=d"));
     }
+
+    @Test
+    void suspendRejectsMultiSlotPool() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new PoolConfig(Paths.get("/x"), null, 2, 14848, 100,
+                        java.util.List.of(), false, true));
+    }
+
+    @Test
+    void suspendAllowsSingleSlotPool() {
+        PoolConfig c = new PoolConfig(Paths.get("/x"), null, 1, 14848, 100,
+                java.util.List.of(), true, true);
+        assertThat(c.debug(), equalTo(true));
+        assertThat(c.suspend(), equalTo(true));
+    }
 }


### PR DESCRIPTION
## What

Adds `-Dglassfish.debug` / `-Dglassfish.suspend` support to the pool container, using the **same property names** as the managed container.

## Why

The pool starts domains on the Maven-plugin side (`PoolProvisioner` → `asadmin start-domain`), not in the test JVM. The `suspend`/`debug` flags inherited via `CommonGlassFishConfiguration` were therefore dead weight on the pool side — by the time the test JVM leases a slot, the domain is already running and `--suspend` can't be retrofitted. This plumbs the flags into the provisioning path where the domain is actually started.

## How

- `PoolProvisioner` now passes `--debug` / `--suspend` to `start-domain`, mirroring `GlassFishServerControl`.
- `PoolConfig` gains `debug`/`suspend` (read from `glassfish.debug`/`glassfish.suspend`), accessors, and a guard.
- `AbstractPoolMojo` exposes both as `@Parameter`s.

## Single-slot constraint

`--suspend` halts the server JVM until a debugger attaches, and all slot clones share one JDWP debug port. So suspend is single-slot only: `PoolConfig` throws `IllegalArgumentException` when `glassfish.suspend` is set with `gf.pool.size > 1`. Run a suspended pool with `-T1`.

## Tests

- New `PoolConfigTest` cases for the guard and the single-slot accept path.
- Full affected-module suite green (42 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)